### PR TITLE
Removes unneeded option, added err checking to port

### DIFF
--- a/v1/plugin/meta.go
+++ b/v1/plugin/meta.go
@@ -29,6 +29,8 @@ const (
 	ConfigBasedRouter
 )
 
+const defaultConcurrencyCount = 5
+
 // MetaOpt is used to apply optional metadata on a plugin
 type MetaOpt func(m *meta)
 
@@ -49,14 +51,6 @@ func ConcurrencyCount(cc int) MetaOpt {
 func Exclusive(e bool) MetaOpt {
 	return func(m *meta) {
 		m.Exclusive = e
-	}
-}
-
-// Unsecure results in unencrypted communication with this plugin.
-// Unsecure overwrites the default (false) for a Meta's Unsecure key.
-func Unsecure(e bool) MetaOpt {
-	return func(m *meta) {
-		m.Unsecure = e
 	}
 }
 
@@ -108,13 +102,18 @@ func newMeta(plType pluginType, name string, version int, opts ...MetaOpt) meta 
 		Name:             name,
 		Version:          version,
 		Type:             plType,
-		ConcurrencyCount: 5,
+		ConcurrencyCount: defaultConcurrencyCount,
 		RoutingStrategy:  LRURouter,
 		RPCType:          2, // GRPC type
 		RPCVersion:       1, // This is v1 lib
+		// Unsecure is a legacy value not used for grpc, but needed to avoid
+		// calling SetKey needlessly.
+		Unsecure: true,
 	}
+
 	for _, opt := range opts {
 		opt(&p)
 	}
+
 	return p
 }

--- a/v1/plugin/plugin.go
+++ b/v1/plugin/plugin.go
@@ -115,7 +115,10 @@ type preamble struct {
 }
 
 func startPlugin(srv server, m meta, p *pluginProxy) int {
-	l, _ := net.Listen("tcp", ":0")
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		panic("Unable to get open port")
+	}
 	l.Close()
 	addr := fmt.Sprintf("127.0.0.1:%v", l.Addr().(*net.TCPAddr).Port)
 	l, err := net.Listen("tcp", addr)


### PR DESCRIPTION
Removes Unsecure as an option for meta. Unsecure is not needed as an
option for plugin authors since the meaning of it (from a snapd
perspective) has to do with legacy plugins and calling SetKey() or not.
SetKey() has no impact on grpc plugins so it makes sense to just
hardcode the value.

Adds error checking to port creation.
