### PR TITLE
Commons error are now public

### DIFF
--- a/examples/publisher/file/file_test.go
+++ b/examples/publisher/file/file_test.go
@@ -46,7 +46,7 @@ func TestFilePublisher(t *testing.T) {
 				},
 			}
 			err := fp.Publish(metrics, plugin.Config{})
-			So(err.Error(), ShouldEqual, "config item file not found")
+			So(err, ShouldEqual, plugin.ErrConfigNotFound)
 		})
 		Convey("Publish with a config file", func() {
 			metrics := []plugin.Metric{

--- a/v1/plugin/config.go
+++ b/v1/plugin/config.go
@@ -19,12 +19,6 @@ limitations under the License.
 
 package plugin
 
-import "fmt"
-
-const (
-	errEmptyKey = "Key cannot be Empty"
-)
-
 // Config is a type alias for map[string]interface{} to allow the
 // helper functions Get{String,Bool,Float,Int} to be defined.
 type Config map[string]interface{}
@@ -40,10 +34,10 @@ func (c Config) GetString(key string) (string, error) {
 	)
 
 	if val, ok = c[key]; !ok {
-		return strout, fmt.Errorf("config item %s not found", key)
+		return strout, ErrConfigNotFound
 	}
 	if strout, ok = val.(string); !ok {
-		return strout, fmt.Errorf("config item %s is not a string", key)
+		return strout, ErrNotAString
 	}
 	return strout, nil
 }
@@ -59,11 +53,11 @@ func (c Config) GetBool(key string) (bool, error) {
 	)
 
 	if val, ok = c[key]; !ok {
-		return bout, fmt.Errorf("config item %s not found", key)
+		return bout, ErrConfigNotFound
 	}
 
 	if bout, ok = val.(bool); !ok {
-		return bout, fmt.Errorf("config item %s is not a bool", key)
+		return bout, ErrNotABool
 	}
 
 	return bout, nil
@@ -80,11 +74,11 @@ func (c Config) GetFloat(key string) (float64, error) {
 	)
 
 	if val, ok = c[key]; !ok {
-		return fout, fmt.Errorf("config item %s not found", key)
+		return fout, ErrConfigNotFound
 	}
 
 	if fout, ok = val.(float64); !ok {
-		return fout, fmt.Errorf("config item %s is not a float64", key)
+		return fout, ErrNotAFloat
 	}
 
 	return fout, nil
@@ -101,11 +95,11 @@ func (c Config) GetInt(key string) (int64, error) {
 	)
 
 	if val, ok = c[key]; !ok {
-		return iout, fmt.Errorf("config item %s not found", key)
+		return iout, ErrConfigNotFound
 	}
 
 	if iout, ok = val.(int64); !ok {
-		return iout, fmt.Errorf("config item %s is not a int64", key)
+		return iout, ErrNotAnInt
 	}
 
 	return iout, nil

--- a/v1/plugin/config_policy.go
+++ b/v1/plugin/config_policy.go
@@ -20,7 +20,6 @@ limitations under the License.
 package plugin
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/intelsdi-x/snap-plugin-lib-go/v1/plugin/rpc"
@@ -50,7 +49,7 @@ func NewConfigPolicy() *ConfigPolicy {
 //		plugin.SetMaxInt(int64),
 func (c *ConfigPolicy) AddNewIntRule(ns []string, key string, req bool, opts ...integerRuleOpt) error {
 	if key == "" {
-		return fmt.Errorf(errEmptyKey)
+		return ErrEmptyKey
 	}
 	rule := rpc.IntegerRule{
 		Required: req,
@@ -73,7 +72,7 @@ func (c *ConfigPolicy) AddNewIntRule(ns []string, key string, req bool, opts ...
 //		plugin.SetDefaultBool(bool)
 func (c *ConfigPolicy) AddNewBoolRule(ns []string, key string, req bool, opts ...boolRuleOpt) error {
 	if key == "" {
-		return fmt.Errorf(errEmptyKey)
+		return ErrEmptyKey
 	}
 	rule := &rpc.BoolRule{
 		Required: req,
@@ -98,7 +97,7 @@ func (c *ConfigPolicy) AddNewBoolRule(ns []string, key string, req bool, opts ..
 //		plugin.SetMaxFloat(float64),
 func (c *ConfigPolicy) AddNewFloatRule(ns []string, key string, req bool, opts ...floatRuleOpt) error {
 	if key == "" {
-		return fmt.Errorf(errEmptyKey)
+		return ErrEmptyKey
 	}
 	rule := &rpc.FloatRule{
 		Required: req,
@@ -121,7 +120,7 @@ func (c *ConfigPolicy) AddNewFloatRule(ns []string, key string, req bool, opts .
 //		plugin.SetDefaultString(string)
 func (c *ConfigPolicy) AddNewStringRule(ns []string, key string, req bool, opts ...stringRuleOpt) error {
 	if key == "" {
-		return fmt.Errorf(errEmptyKey)
+		return ErrEmptyKey
 	}
 	rule := &rpc.StringRule{
 		Required: req,

--- a/v1/plugin/errors.go
+++ b/v1/plugin/errors.go
@@ -1,0 +1,17 @@
+package plugin
+
+import "fmt"
+
+var (
+	// ErrEmptyKey is returned when a Rule with an empty key is created
+	ErrEmptyKey = fmt.Errorf("Key cannot be Empty")
+
+	// ErrConfigNotFound is returned when a config doesn't exist in the config map
+	ErrConfigNotFound = fmt.Errorf("config item not found")
+
+	// ErrNotA<type> is returned when the found config item doesn't have the expected type
+	ErrNotAString = fmt.Errorf("config item is not a string")
+	ErrNotAnInt   = fmt.Errorf("config item is not an int64")
+	ErrNotABool   = fmt.Errorf("config item is not a boolean")
+	ErrNotAFloat  = fmt.Errorf("config item is not a float64")
+)

--- a/v1/plugin/metric.go
+++ b/v1/plugin/metric.go
@@ -236,6 +236,7 @@ func NewNamespace(ns ...string) namespace {
 	}
 	return n
 }
+
 // CopyNamespace copies array of namespace elements to new array
 func CopyNamespace(src namespace) namespace {
 	dst := make([]namespaceElement, len(src))


### PR DESCRIPTION
What changed:
- Error and there description are in `errors.go`.
- Errors are public.
- Publisher example will now test a public error instead of an hardcoded string.