### PR TITLE
SDI-2115:issue334: Remove metric.String()

### DIFF
--- a/examples/collector/rand/rand.go
+++ b/examples/collector/rand/rand.go
@@ -62,10 +62,10 @@ type RandCollector struct {
 
 /*  CollectMetrics collects metrics for testing.
 
-	CollectMetrics() will be called by Snap when a task that collects one of the metrics returned from this plugins
-	GetMetricTypes() is started. The input will include a slice of all the metric types being collected.
+CollectMetrics() will be called by Snap when a task that collects one of the metrics returned from this plugins
+GetMetricTypes() is started. The input will include a slice of all the metric types being collected.
 
-	The output is the collected metrics as plugin.Metric and an error.
+The output is the collected metrics as plugin.Metric and an error.
 */
 func (RandCollector) CollectMetrics(mts []plugin.Metric) ([]plugin.Metric, error) {
 	metrics := []plugin.Metric{}
@@ -96,7 +96,7 @@ func (RandCollector) CollectMetrics(mts []plugin.Metric) ([]plugin.Metric, error
 			}
 			metrics = append(metrics, mts[idx])
 		} else {
-			return nil, fmt.Errorf("Invalid metric: %v", mt.Namespace.String())
+			return nil, fmt.Errorf("Invalid metric: %v", mt.Namespace.Strings())
 		}
 	}
 	return metrics, nil

--- a/examples/publisher/file/file.go
+++ b/examples/publisher/file/file.go
@@ -55,7 +55,7 @@ func (f FPublisher) Publish(mts []plugin.Metric, cfg plugin.Config) error {
 
 	for _, m := range mts {
 		fmt.Fprintf(writer, "%s|%v|%d|%s|%s|%s|%v|%v\n",
-			m.Namespace.String(),
+			m.Namespace.Strings(),
 			m.Data,
 			m.Version,
 			m.Unit,

--- a/v1/plugin/collector_proxy_test.go
+++ b/v1/plugin/collector_proxy_test.go
@@ -46,7 +46,7 @@ func TestGetMetricTypes(t *testing.T) {
 			for _, m := range r.GetMetrics() {
 				tm := fromProtoMetric(m)
 				idx := fmt.Sprintf("%s.%d", tm.Namespace, tm.Version)
-				So(tm.Namespace.String(), ShouldEqual, metricMap[idx].Namespace.String())
+				So(tm.Namespace.Strings(), ShouldResemble, metricMap[idx].Namespace.Strings())
 				So(tm.Tags, ShouldEqual, metricMap[idx].Tags)
 			}
 		})
@@ -92,7 +92,15 @@ func TestCollectMetrics(t *testing.T) {
 			for _, v := range reply.GetMetrics() {
 				m := fromProtoMetric(v)
 				So(v.Tags, ShouldEqual, m.Tags)
-				So("/"+v.Namespace[0].Value, ShouldEqual, m.Namespace.String())
+
+				var nsArr []string
+				ns := v.GetNamespace()
+				for i := range ns {
+					nsArr = append(nsArr, ns[i].Value)
+				}
+				Convey(fmt.Sprintf("colleting namespace: %v", m.Namespace.Strings()), func() {
+					So(nsArr, ShouldResemble, m.Namespace.Strings())
+				})
 			}
 		})
 	})

--- a/v1/plugin/metric.go
+++ b/v1/plugin/metric.go
@@ -186,13 +186,6 @@ func fromProtoNamespace(ns []*rpc.NamespaceElement) namespace {
 
 type namespace []namespaceElement
 
-// String returns the string representation of the namespace with "/" joining
-// the elements of the namespace.  A leading "/" is added.
-func (n namespace) String() string {
-	ns := n.Strings()
-	return "/" + strings.Join(ns, "/")
-}
-
 // Strings returns an array of strings that represent the elements of the
 // namespace.
 func (n namespace) Strings() []string {

--- a/v1/plugin/metric_test.go
+++ b/v1/plugin/metric_test.go
@@ -37,11 +37,9 @@ func TestMetric(t *testing.T) {
 
 	Convey("Test Metrics", t, func() {
 		for _, c := range tc {
-			Convey(fmt.Sprintf("Test Metrics %+v", c.input.Namespace.String()), func() {
+			Convey(fmt.Sprintf("Test Metrics %+v", c.input.Namespace.Strings()), func() {
 				ns := c.input.Namespace
-				nsStr := ns.String()
 				nsArr := ns.Strings()
-				So(strings.TrimLeft(nsStr, "/"), ShouldEqual, strings.Join(nsArr, "/"))
 				So(ns.Key(), ShouldEqual, strings.Join(nsArr, "."))
 
 				for i, n := range ns {
@@ -73,7 +71,7 @@ func TestToFromProtoNamespace(t *testing.T) {
 
 	Convey("Test ToFromProtoNamespace", t, func() {
 		for _, ns := range nss {
-			Convey(fmt.Sprintf("Test ToFromProtoNamespace %+v", ns.String()), func() {
+			Convey(fmt.Sprintf("Test ToFromProtoNamespace %+v", ns.Strings()), func() {
 				protoNs := toProtoNamespace(ns)
 				fromProtoNs := fromProtoNamespace(protoNs)
 				So(fromProtoNs, ShouldResemble, ns)
@@ -87,7 +85,7 @@ func TestToFromProtoMetric(t *testing.T) {
 
 	Convey("Test ToFromProtoMetric", t, func() {
 		for _, c := range tc {
-			Convey(fmt.Sprintf("Test ToFromProtoMetric %+v", c.input.Namespace.String()), func() {
+			Convey(fmt.Sprintf("Test ToFromProtoMetric %+v", c.input.Namespace.Strings()), func() {
 				protoMetric, err := toProtoMetric(c.input)
 				So(err, ShouldBeNil)
 
@@ -144,7 +142,7 @@ func TestMetricTime(t *testing.T) {
 
 	Convey("Test metric has no default time", t, func() {
 		for _, c := range tc {
-			Convey(fmt.Sprintf("Test metric has no default time %+v", c.input.Namespace.String()), func() {
+			Convey(fmt.Sprintf("Test metric has no default time %+v", c.input.Namespace.Strings()), func() {
 				protoMetric, err := toProtoMetric(c.input)
 				So(err, ShouldBeNil)
 
@@ -158,7 +156,7 @@ func TestMetricTime(t *testing.T) {
 
 	Convey("Test metric has time set", t, func() {
 		for _, c := range tc {
-			Convey(fmt.Sprintf("Test metric has time set %+v", c.input.Namespace.String()), func() {
+			Convey(fmt.Sprintf("Test metric has time set %+v", c.input.Namespace.Strings()), func() {
 				protoMetric, err := toProtoMetric(c.input)
 				So(err, ShouldBeNil)
 


### PR DESCRIPTION
### Summary of Changes
* removed metric.String() method
* updated relevant tests that use that method.
* provided the private toString function in each package.

### Tests done
* small and medium tests.