### PR TITLE
Removes Namespace.Key().

### DIFF
--- a/v1/plugin/metric.go
+++ b/v1/plugin/metric.go
@@ -21,7 +21,6 @@ package plugin
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/intelsdi-x/snap-plugin-lib-go/v1/plugin/rpc"
@@ -194,12 +193,6 @@ func (n namespace) Strings() []string {
 		ns = append(ns, namespaceElement.Value)
 	}
 	return ns
-}
-
-// Key returns a string representation of the namespace with "." joining
-// the elements of the namespace.
-func (n namespace) Key() string {
-	return strings.Join(n.Strings(), ".")
 }
 
 // IsDynamic returns true if there is any element of the namespace which is

--- a/v1/plugin/metric_test.go
+++ b/v1/plugin/metric_test.go
@@ -24,7 +24,6 @@ package plugin
 import (
 	"fmt"
 	"reflect"
-	"strings"
 	"testing"
 	"time"
 
@@ -39,8 +38,6 @@ func TestMetric(t *testing.T) {
 		for _, c := range tc {
 			Convey(fmt.Sprintf("Test Metrics %+v", c.input.Namespace.Strings()), func() {
 				ns := c.input.Namespace
-				nsArr := ns.Strings()
-				So(ns.Key(), ShouldEqual, strings.Join(nsArr, "."))
 
 				for i, n := range ns {
 					elem := ns.Element(i)


### PR DESCRIPTION
Fixes #36. cc @IRCody @kindermoumoute.
- Also removes the use of Key() in the test.
