### PR TITLE
Typos and snaptel conversion

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -3,7 +3,7 @@ Here you will find example plugins that cover the basics for writing collector, 
 
 ## Build Plugins & Use with Snap
 
-To get these example collector, processor, and publisher plugins to build properly and work with Snap you will need to have [glide](https://glide.sh/) installed in your $PATH. You should also add snapctl and snapd in your $PATH. 
+To get these example collector, processor, and publisher plugins to build properly and work with Snap you will need to have [glide](https://glide.sh/) installed in your $PATH. You should also add snaptel and snapteld in your $PATH. 
 
 To test these plugins with Snap, you will need to have [Snap](https://github.com/intelsdi-x/snap) installed, check out these docs for [Snap setup details](https://github.com/intelsdi-x/snap/blob/master/docs/BUILD_AND_TEST.md#getting-started).
 
@@ -47,12 +47,12 @@ $ glide up
 
 ###3. Build the collector, processor, and/or publisher plugins in the examples folder.
     Use the `go build` command to generate the example binary files for the collector, processor, and publisher.
-    option -o outputs the binary to the specified name 
+    option -o outputs the binary to the specified name
 
 ```
 $ go build -o example-collector examples/collector/main.go
-$ go build -o example-processor examples/processor/main.go 
-$ go build -o example-publisher examples/publisher/main.go 
+$ go build -o example-processor examples/processor/main.go
+$ go build -o example-publisher examples/publisher/main.go
 ```
 
 ###4. Run Snap, Load Plugins, and Run Tasks
@@ -61,7 +61,7 @@ You can now try [running Snap](https://github.com/intelsdi-x/snap#running-snap),
 Below are some sample commands to try:
 
 ```
-$ snapctl plugin load example-collector
+$ snaptel plugin load example-collector
 Plugin loaded
 Name: test-rand-collector
 Version: 1
@@ -69,17 +69,17 @@ Type: collector
 Signed: false
 Loaded Time: Fri, 23 Sep 2016 17:41:44 PDT
 
-$ snapctl plugin list
+$ snaptel plugin list
 NAME 			 VERSION 	 TYPE 		 SIGNED 	 STATUS 	 LOADED TIME
 test-rand-collector 	 1 		 collector 	 false 		 loaded 	 Fri, 23 Sep 2016 17:41:44 PDT
 
-$ snapctl metric list
+$ snaptel metric list
 NAMESPACE 		 VERSIONS
 /random/float 		 1
 /random/integer 	 1
 /random/string 		 1
 
-$ snapctl plugin load example-processor
+$ snaptel plugin load example-processor
 Plugin loaded
 Name: test-reverse-processor
 Version: 1
@@ -87,7 +87,7 @@ Type: processor
 Signed: false
 Loaded Time: Fri, 23 Sep 2016 17:44:12 PDT
 
-$ snapctl plugin load example-publisher
+$ snaptel plugin load example-publisher
 Plugin loaded
 Name: test-file-publisher
 Version: 1
@@ -95,7 +95,7 @@ Type: publisher
 Signed: false
 Loaded Time: Fri, 23 Sep 2016 17:44:23 PDT
 
-$ snapctl plugin list
+$ snaptel plugin list
 NAME 			 VERSION 	 TYPE 		 SIGNED 	 STATUS 	 LOADED TIME
 test-rand-collector 	 1 		 collector 	 false 		 loaded 	 Fri, 23 Sep 2016 17:41:44 PDT
 test-reverse-processor 	 1 		 processor 	 false 		 loaded 	 Fri, 23 Sep 2016 17:44:12 PDT
@@ -104,7 +104,7 @@ test-file-publisher 	 1 		 publisher 	 false 		 loaded 	 Fri, 23 Sep 2016 17:44:
 ```
 
 ### Create a task.
-You can create a task.yml file for these examples using the following code. 
+You can create a task.yml file for these examples using the following code.
 Discover [how tasks work](https://github.com/intelsdi-x/snap/blob/master/docs/TASKS.md).
 
 task.yml

--- a/examples/collector/README.md
+++ b/examples/collector/README.md
@@ -7,7 +7,7 @@ For your collector plugin, create a new repository and name your plugin project 
 
 >snap-plugin-[plugin-type]-[plugin-name]
 
-For example: 
+For example:
 >snap-plugin-collector-rand
 
 
@@ -40,7 +40,7 @@ In order to write a plugin for Snap, it is necessary to define a few methods to 
 
 
 ```go
-// Plugin is an interface shared by all plugins and must implemented by each plugin to communicate with Snap.
+// Plugin is an interface shared by all plugins and must be implemented by each plugin to communicate with Snap.
 type Plugin interface {
 	GetConfigPolicy() (ConfigPolicy, error)
 }
@@ -73,7 +73,7 @@ The available options are defined in [plugin/meta.go](https://github.com/intelsd
 // ConcurrencyCount is the max number of concurrent calls the plugin
 // should take.  For example:
 // If there are 5 tasks using the plugin and its concurrency count is 2,
-// snapd will keep 3 plugin instances running.
+// snapteld will keep 3 plugin instances running.
 // ConcurrencyCount overwrites the default (5) for a Meta's ConcurrencyCount.
 func ConcurrencyCount(cc int) MetaOpt {
 }
@@ -95,7 +95,7 @@ func Unsecure(e bool) MetaOpt {
 func RoutingStrategy(r router) MetaOpt {
 }
 
-// CacheTTL will override the default cache TTL for the this plugin. snapd
+// CacheTTL will override the default cache TTL for the this plugin. snapteld
 // caches metrics on the daemon side for a default of 500ms.
 // CacheTTL overwrites the default (500ms) for a Meta's CacheTTL.
 func CacheTTL(t time.Duration) MetaOpt {
@@ -140,6 +140,3 @@ package rand
 You've made a plugin! Now it's time to share it. Create a release by following these [steps](https://help.github.com/articles/creating-releases/). We recommend that your release version match your plugin version, see example [here](https://github.com/intelsdi-x/snap-plugin-lib-go/blob/master/examples/collector/main.go#L29).
 
 Don't forget to announce your plugin release on [slack](https://intelsdi-x.herokuapp.com/) and get your plugin added to the [Plugin Catalog](https://github.com/intelsdi-x/snap/blob/master/docs/PLUGIN_CATALOG.md)!
-
-
-

--- a/examples/processor/README.md
+++ b/examples/processor/README.md
@@ -38,7 +38,7 @@ In order to write a plugin for Snap, it is necessary to define a few methods to 
 
 
 ```go
-// Plugin is an interface shared by all plugins and must implemented by each plugin to communicate with Snap.
+// Plugin is an interface shared by all plugins and must be implemented by each plugin to communicate with Snap.
 type Plugin interface {
 	GetConfigPolicy() (ConfigPolicy, error)
 }
@@ -73,7 +73,7 @@ The available options are defined in [plugin/meta.go](https://github.com/intelsd
 // ConcurrencyCount is the max number of concurrent calls the plugin
 // should take.  For example:
 // If there are 5 tasks using the plugin and its concurrency count is 2,
-// snapd will keep 3 plugin instances running.
+// snapteld will keep 3 plugin instances running.
 // ConcurrencyCount overwrites the default (5) for a Meta's ConcurrencyCount.
 func ConcurrencyCount(cc int) MetaOpt {
 }
@@ -95,7 +95,7 @@ func Unsecure(e bool) MetaOpt {
 func RoutingStrategy(r router) MetaOpt {
 }
 
-// CacheTTL will override the default cache TTL for the this plugin. snapd
+// CacheTTL will override the default cache TTL for the this plugin. snapteld
 // caches metrics on the daemon side for a default of 500ms.
 // CacheTTL overwrites the default (500ms) for a Meta's CacheTTL.
 func CacheTTL(t time.Duration) MetaOpt {

--- a/examples/publisher/README.md
+++ b/examples/publisher/README.md
@@ -38,7 +38,7 @@ In order to write a plugin for Snap, it is necessary to define a few methods to 
 
 
 ```go
-// Plugin is an interface shared by all plugins and must implemented by each plugin to communicate with Snap.
+// Plugin is an interface shared by all plugins and must be implemented by each plugin to communicate with Snap.
 type Plugin interface {
 	GetConfigPolicy() (ConfigPolicy, error)
 }
@@ -73,7 +73,7 @@ The available options are defined in [plugin/meta.go](https://github.com/intelsd
 // ConcurrencyCount is the max number of concurrent calls the plugin
 // should take.  For example:
 // If there are 5 tasks using the plugin and its concurrency count is 2,
-// snapd will keep 3 plugin instances running.
+// snapteld will keep 3 plugin instances running.
 // ConcurrencyCount overwrites the default (5) for a Meta's ConcurrencyCount.
 func ConcurrencyCount(cc int) MetaOpt {
 }
@@ -95,7 +95,7 @@ func Unsecure(e bool) MetaOpt {
 func RoutingStrategy(r router) MetaOpt {
 }
 
-// CacheTTL will override the default cache TTL for the this plugin. snapd
+// CacheTTL will override the default cache TTL for the this plugin. snapteld
 // caches metrics on the daemon side for a default of 500ms.
 // CacheTTL overwrites the default (500ms) for a Meta's CacheTTL.
 func CacheTTL(t time.Duration) MetaOpt {

--- a/v1/plugin/meta.go
+++ b/v1/plugin/meta.go
@@ -37,7 +37,7 @@ type MetaOpt func(m *meta)
 // ConcurrencyCount is the max number of concurrent calls the plugin
 // should take.  For example:
 // If there are 5 tasks using the plugin and its concurrency count is 2,
-// snapd will keep 3 plugin instances running.
+// snapteld will keep 3 plugin instances running.
 // ConcurrencyCount overwrites the default (5) for a Meta's ConcurrencyCount.
 func ConcurrencyCount(cc int) MetaOpt {
 	return func(m *meta) {
@@ -63,7 +63,7 @@ func RoutingStrategy(r router) MetaOpt {
 	}
 }
 
-// CacheTTL will override the default cache TTL for the this plugin. snapd
+// CacheTTL will override the default cache TTL for the this plugin. snapteld
 // caches metrics on the daemon side for a default of 500ms.
 // CacheTTL overwrites the default (500ms) for a Meta's CacheTTL.
 func CacheTTL(t time.Duration) MetaOpt {


### PR DESCRIPTION
I was using the repo and found some minor corrections. Search and replace of snapctl to snaptel and snapd to snapteld. Also a grammatical typo correction.