### PR TITLE
Preliminary support for configuring TLS channel between framework and…

### DIFF
--- a/examples/collector/main.go
+++ b/examples/collector/main.go
@@ -30,5 +30,5 @@ const (
 )
 
 func main() {
-	plugin.StartCollector(rand.RandCollector{}, pluginName, pluginVersion)
+	plugin.StartCollector(rand.RandCollector{}, pluginName, pluginVersion, plugin.Unsecure(false))
 }

--- a/examples/processor/main.go
+++ b/examples/processor/main.go
@@ -30,5 +30,5 @@ const (
 )
 
 func main() {
-	plugin.StartProcessor(reverse.RProcessor{}, pluginName, pluginVersion)
+	plugin.StartProcessor(reverse.RProcessor{}, pluginName, pluginVersion, plugin.Unsecure(false))
 }

--- a/examples/publisher/main.go
+++ b/examples/publisher/main.go
@@ -30,5 +30,5 @@ const (
 )
 
 func main() {
-	plugin.StartPublisher(file.FPublisher{}, pluginName, pluginVersion)
+	plugin.StartPublisher(file.FPublisher{}, pluginName, pluginVersion, plugin.Unsecure(false))
 }

--- a/examples/tls/README.md
+++ b/examples/tls/README.md
@@ -1,0 +1,128 @@
+## Example running TLS secured communication between plugins and framework
+
+### Overview
+
+The TLS demo scenario is here. 
+* Demo is supposed to test TLS communication
+in the scenario where all parties are running on a localhost.
+* Steps for the demo were tested on Ubuntu 16.04.
+
+Overview of the steps:
+1. Generate own CA (Certificate Authority) certificate for demo.
+2. Generate and sign demo keys for server- (plugins) and client- 
+(server) gRPC side.
+3. Start Snap.
+4. Build snap-plugin-lib-go example plugins
+5. Load plugins with certificates given in arguments.
+6. Create a task.
+
+#### Generating demo CA certificate
+
+```sh
+mkdir CA; cd CA
+mkdir certs crl newcerts private
+echo "01" > serial
+cp /dev/null index.txt
+cp /etc/ssl/openssl.cnf openssl.cnf
+grep openssl.cnf -ie DemoCA
+
+## alter OpenSSL configuration
+sed 's#./DemoCA#.#gI' -i openssl.cnf
+sed 's#cacert.pem#taocacert.pem#gI' -i openssl.cnf
+sed 's#cakey.pem#taocakey.pem#gI' -i openssl.cnf
+## manual step - add an entry to section [ usr_cert ] for local address
+    subjectAltName=IP:127.0.0.1
+## diff to original openssl conf should look like this:
+
+diff openssl.cnf /etc/ssl/openssl.cnf                                                                                                       [1/5307]
+42c42
+< dir           = .             # Where everything is kept
+---
+> dir           = ./demoCA              # Where everything is kept
+50c50
+< certificate   = $dir/taocacert.pem    # The CA certificate
+---
+> certificate   = $dir/cacert.pem       # The CA certificate
+55c55
+< private_key   = $dir/private/taocakey.pem# The private key
+---
+> private_key   = $dir/private/cakey.pem# The private key
+200d199
+< subjectAltName=IP:127.0.0.1
+331c330
+< dir           = .             # TSA root directory
+---
+> dir           = ./demoCA              # TSA root directory
+336c335
+< certs         = $dir/taocacert.pem    # Certificate chain to include in reply
+---
+> certs         = $dir/cacert.pem       # Certificate chain to include in reply
+
+## generate and install CA certificate
+## enter any data, but rememeber the password encrypting the private key
+openssl req -new -x509 -keyout private/taocakey.pem -out taocacert.pem -days 365 -config openssl.cnf
+sudo cp taocacert.pem /usr/local/share/ca-certificates/taocacert.crt
+## this will link demo certificate as trusted in system
+sudo update-ca-certificates
+```
+
+#### Generate and sign demo keys for server- (plugins) and client- (server) gRPC side.
+
+```sh
+## request and sign server certificate
+## upon request enter any data for all fields except CN - give `127.0.0.1`
+openssl req -nodes -new -x509 -keyout taoserverkey.pem -out taoserverreq.pem -days 365 -config openssl.cnf
+openssl x509 -x509toreq -in taoserverreq.pem -signkey taoserverkey.pem -out tmp.pem
+openssl ca -config openssl.cnf -policy policy_anything -out taoservercert.pem -infiles tmp.pem
+rm tmp.pem
+## request and sign client certificate
+## upon request enter any data for all fields except CN - give `127.0.0.1`
+openssl req -nodes -new -x509 -keyout taoclientkey.pem -out taoclientreq.pem -days 365 -config openssl.cnf
+openssl x509 -x509toreq -in taoclientreq.pem -signkey taoclientkey.pem -out tmp.pem
+openssl ca -config openssl.cnf -policy policy_anything -out taoclientcert.pem -infiles tmp.pem
+rm tmp.pem
+sudo cp taoserver*.pem taoclient*.pem /tmp
+```
+
+#### Start Snap as usual
+
+`snapteld --plugin-trust 0 --log-level 1` 
+
+#### Build snap-plugin-lib-go example plugins
+
+`for k in collector processor publisher; do go build -o example-$k examples/$k/main.go; done`
+
+#### Load plugins with certificates given in arguments
+
+```sh
+snaptel plugin load example-processor --plugin-cert=/tmp/taoclientcert.pem --plugin-key=/tmp/taoclientkey.pem
+snaptel plugin load example-collector --plugin-cert=/tmp/taoclientcert.pem --plugin-key=/tmp/taoclientkey.pem
+snaptel plugin load example-publisher --plugin-cert=/tmp/taoclientcert.pem --plugin-key=/tmp/taoclientkey.pem
+```
+
+#### Create and watch a task
+
+```sh
+snaptel task create -t examples/task.yml
+#
+#Using task manifest to create task
+#Task created
+#ID: 9eb91d45-3427-4847-b119-47d3cd43b793
+#Name: Task-9eb91d45-3427-4847-b119-47d3cd43b793
+#State: Running
+#
+snaptel task watch 9eb91d45-3427-4847-b119-47d3cd43b793
+#
+#Watching Task (9eb91d45-3427-4847-b119-47d3cd43b793):
+
+snaptel task watch 
+```
+
+- where `examples/task.yml` is the example given in [readme for examples/](../README.md).  
+
+### Known issues
+
+Client doesn't yet authenticate to servers - ie.: framework doesn't
+provide its certificate. Additionally, the plugins do not yet demand the
+certificate from framework.
+

--- a/v1/plugin/meta.go
+++ b/v1/plugin/meta.go
@@ -19,7 +19,11 @@ limitations under the License.
 
 package plugin
 
-import "time"
+import (
+	"time"
+	"fmt"
+	"os"
+)
 
 type router int
 
@@ -72,6 +76,12 @@ func CacheTTL(t time.Duration) MetaOpt {
 	}
 }
 
+func Unsecure(u bool) MetaOpt {
+	return func(m *meta) {
+		m.Unsecure = u
+	}
+}
+
 type pluginType int
 
 const (
@@ -94,10 +104,13 @@ type meta struct {
 	Unsecure         bool
 	CacheTTL         time.Duration
 	RoutingStrategy  router
+	CertPath         string
+	KeyPath          string
 }
 
 // newMeta sets defaults, applies options, and then returns a meta struct
 func newMeta(plType pluginType, name string, version int, opts ...MetaOpt) meta {
+	fmt.Fprintf(os.Stderr, "DEBUG: generating new meta; plugin_name= %v, my pid#= %v", name, os.Getpid())
 	p := meta{
 		Name:             name,
 		Version:          version,

--- a/v1/plugin/plugin.go
+++ b/v1/plugin/plugin.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/intelsdi-x/snap-plugin-lib-go/v1/plugin/rpc"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 )
 
 // Plugin is the base plugin type. All plugins must implement GetConfigPolicy.
@@ -60,10 +61,21 @@ type Publisher interface {
 // StartCollector is given a Collector implementation and its metadata,
 // generates a response for the initial stdin / stdout handshake, and starts
 // the plugin's gRPC server.
-func StartCollector(plugin Collector, name string, version int, opts ...MetaOpt) int {
-	getArgs()
+func StartCollector (plugin Collector, name string, version int, opts ...MetaOpt) int {
+	args, _ := getArgs()
 	m := newMeta(collectorType, name, version, opts...)
-	server := grpc.NewServer()
+	m.CertPath = args.CertPath
+	m.KeyPath = args.KeyPath
+	creds, err := credentials.NewServerTLSFromFile(args.CertPath, args.KeyPath)
+	if err != nil {
+	  panic(err)
+	}
+	//lis, err := net.Listen("tcp", port)
+	//if err != nil {
+	//  panic(err)
+	//}
+	//server := grpc.NewServer()
+	server := grpc.NewServer(grpc.Creds(creds))
 	// TODO(danielscottt) SSL
 	proxy := &collectorProxy{
 		plugin:      plugin,
@@ -77,10 +89,18 @@ func StartCollector(plugin Collector, name string, version int, opts ...MetaOpt)
 // generates a response for the initial stdin / stdout handshake, and starts
 // the plugin's gRPC server.
 func StartProcessor(plugin Processor, name string, version int, opts ...MetaOpt) int {
-	getArgs()
+	args, _ := getArgs()
 	m := newMeta(processorType, name, version, opts...)
-	server := grpc.NewServer()
+	//server := grpc.NewServer()
+	m.CertPath = args.CertPath
+	m.KeyPath = args.KeyPath
+	creds, err := credentials.NewServerTLSFromFile(args.CertPath, args.KeyPath)
+	if err != nil {
+	  panic(err)
+	}
+
 	// TODO(danielscottt) SSL
+	server := grpc.NewServer(grpc.Creds(creds))
 	proxy := &processorProxy{
 		plugin:      plugin,
 		pluginProxy: *newPluginProxy(plugin),
@@ -93,10 +113,18 @@ func StartProcessor(plugin Processor, name string, version int, opts ...MetaOpt)
 // generates a response for the initial stdin / stdout handshake, and starts
 // the plugin's gRPC server.
 func StartPublisher(plugin Publisher, name string, version int, opts ...MetaOpt) int {
-	getArgs()
+	args, _ := getArgs()
 	m := newMeta(publisherType, name, version, opts...)
-	server := grpc.NewServer()
+	//server := grpc.NewServer()
+		m.CertPath = args.CertPath
+	m.KeyPath = args.KeyPath
+	creds, err := credentials.NewServerTLSFromFile(args.CertPath, args.KeyPath)
+	if err != nil {
+	  panic(err)
+	}
+
 	// TODO(danielscottt) SSL
+	server := grpc.NewServer(grpc.Creds(creds))
 	proxy := &publisherProxy{
 		plugin:      plugin,
 		pluginProxy: *newPluginProxy(plugin),

--- a/v1/plugin/session.go
+++ b/v1/plugin/session.go
@@ -32,18 +32,23 @@ type Arg struct {
 
 	// enable pprof
 	Pprof bool
+
+	CertPath string
+	KeyPath string
 }
 
 // getArgs returns plugin args or default ones
-func getArgs() error {
+func getArgs() (*Arg, error) {
 	pluginArg := &Arg{}
 	if os.Args[1] == "" {
-		return nil
+		fmt.Fprintf(os.Stderr, "DEBUG: no args")
+		return nil, nil
 	}
 	err := json.Unmarshal([]byte(os.Args[1]), pluginArg)
 	if err != nil {
-		return err
+		return nil, err
 	}
+	fmt.Fprintf(os.Stderr, "DEBUG: got args: %#v", pluginArg)
 
 	// If no port was provided we let the OS select a port for us.
 	// This is safe as address is returned in the Response and keep
@@ -57,10 +62,10 @@ func getArgs() error {
 		PingTimeoutDurationDefault = pluginArg.PingTimeoutDuration
 	}
 	if pluginArg.Pprof {
-		return getPort()
+		return pluginArg, getPort()
 	}
 
-	return nil
+	return pluginArg, nil
 }
 
 func getPort() error {


### PR DESCRIPTION
… plugin

See examples/README.md for instructions on how to test it.
- added parsing arguments from command line (including CertPath and KeyPath - paths to certificate files),
- added starting gRPC server with TLS security basing on provided certificates.
- added a short documentation on how to test the TLS communication.