### PR TITLE
Fixes #72, set rpcType as gRPCStream for streaming plugin

### DIFF
--- a/v1/plugin/plugin.go
+++ b/v1/plugin/plugin.go
@@ -268,6 +268,7 @@ func StartPublisher(plugin Publisher, name string, version int, opts ...MetaOpt)
 // generates a response for the initial stdin / stdout handshake, and starts
 // the plugin's gRPC server.
 func StartStreamCollector(plugin StreamCollector, name string, version int, opts ...MetaOpt) int {
+	opts = append(opts, rpcType(gRPCStream))
 	server, m, err := buildGRPCServer(collectorType, name, version, opts...)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Summary of changes:
- set rpcType in meta as gRPCStream for streaming plugin so it is return to the state before #68, see [L83](https://github.com/intelsdi-x/snap-plugin-lib-go/pull/68/files#diff-01c2cbb747cc453d78a7b29d3e51c7d7L83)

