### PR TITLE
Expand mock plugin-collector-rand abilities

### DIFF
--- a/examples/snap-plugin-collector-rand/README.md
+++ b/examples/snap-plugin-collector-rand/README.md
@@ -140,3 +140,15 @@ package rand
 You've made a plugin! Now it's time to share it. Create a release by following these [steps](https://help.github.com/articles/creating-releases/). We recommend that your release version match your plugin version, see example [here](https://github.com/intelsdi-x/snap-plugin-lib-go/blob/master/examples/snap-plugin-collector-rand/main.go#L29).
 
 Don't forget to announce your plugin release on [slack](https://intelsdi-x.herokuapp.com/) and get your plugin added to the [Plugin Catalog](https://github.com/intelsdi-x/snap/blob/master/docs/PLUGIN_CATALOG.md)!
+
+## Notice
+This plugin is also used for testing snap-plugin-lib-go. For that reason, we have added some additional capabilities to it for testing the following situations:
+- mock situation when a plugin requires a config to load
+  - **How to test:**
+When running plugin set the `-required-config` flag. Ex: `./snap-plugin-collector-rand -required-config`
+When this is set, the plugin will expect you to pass in a config item with the key `value`. If you don't pass in a config item or if that config doesn't contain the `value` key, an error will be thrown saying missing config item. Example: `./snap-plugin-collector-rand -required-config -config '{"value":"something"}'`
+
+- mock situation when a plugin does not have required dependencies
+  - **How to test:**
+When running the plugin, pass the `depsReq` key in through the config. Example: `./snap-plugin-collector-rand -required-config -config '{"depsReq":true}'`
+This will always throw an error, as it is simply testing how the plugin-lib handles the error when thrown. 

--- a/examples/snap-plugin-collector-rand/rand/rand.go
+++ b/examples/snap-plugin-collector-rand/rand/rand.go
@@ -60,6 +60,10 @@ var req bool = false
 func init() {
 	rand.Seed(42)
 
+	//The required-config flag is added for testing plugin-lib-go.
+	//When the flag is set, an additional policy will be added in GetConfigPolicy().
+	//This additional policy has a required field. This simulates
+	//the situation when a plugin requires a config to load.
 	plugin.App = cli.NewApp()
 	plugin.App.Flags = []cli.Flag{
 		cli.BoolFlag{
@@ -97,7 +101,7 @@ func (RandCollector) CollectMetrics(mts []plugin.Metric) ([]plugin.Metric, error
 			var err error
 			mts[idx].Data, err = mts[idx].Config.GetString("value")
 			if err != nil {
-				return nil, fmt.Errorf("Invalid or missing value field.")
+				return nil, fmt.Errorf("Invalid or missing value key.")
 			}
 			metrics = append(metrics, mts[idx])
 		} else if mt.Namespace[len(mt.Namespace)-1].Value == "integer" {
@@ -138,6 +142,7 @@ func (RandCollector) CollectMetrics(mts []plugin.Metric) ([]plugin.Metric, error
 	The metrics returned will be advertised to users who list all the metrics and will become targetable by tasks.
 */
 func (RandCollector) GetMetricTypes(cfg plugin.Config) ([]plugin.Metric, error) {
+	//Simulate throwing error when a config is requried but not passed in
 	if req && len(cfg) < 1 {
 		return nil, fmt.Errorf("! When -required-config is set you must provide a config. Example: -config '{\"key\":\"kelly\", \"spirit-animal\":\"coatimundi\"}'\n")
 	}
@@ -174,6 +179,7 @@ func (RandCollector) GetMetricTypes(cfg plugin.Config) ([]plugin.Metric, error) 
 func (RandCollector) GetConfigPolicy() (plugin.ConfigPolicy, error) {
 	policy := plugin.NewConfigPolicy()
 
+	//The required-config flag is used for testing plugin-lib-go
 	if req {
 		policy.AddNewStringRule([]string{"static", "string"},
 			"value",


### PR DESCRIPTION
- Added access to cli
- Optional flag to mock behavior of a required config
- Added an optionally required metric
- Added mock behavior for testing a plugin that requires dependencies, this is accessed by passing "depsReq" in through the config

Changes to this mock are related to testing plugin diagnostics #66 