### PR TITLE
Add support for configuring a streaming collector

### DIFF
--- a/examples/streaming/rand/rand.go
+++ b/examples/streaming/rand/rand.go
@@ -61,7 +61,7 @@ type RandCollector struct {
 	metrics []plugin.Metric
 }
 
-// StreamMetrics taks both an in and out channel of []plugin.Metric
+// StreamMetrics takes both an in and out channel of []plugin.Metric
 //
 // The metrics_in channel is used to set/update the metrics that Snap is
 // currently requesting to be collected by the plugin.

--- a/v1/plugin/plugin_test.go
+++ b/v1/plugin/plugin_test.go
@@ -242,7 +242,7 @@ type mockStreamer struct {
 	maxCollectDuration time.Duration
 	inMetric           chan []Metric
 	outMetric          chan []Metric
-	action             func(chan []Metric, time.Duration)
+	action             func(chan []Metric, time.Duration, []Metric)
 }
 
 func newMockStreamer() *mockStreamer {
@@ -253,12 +253,12 @@ func newMockErrStreamer() *mockStreamer {
 	return &mockStreamer{err: errors.New("empty")}
 }
 
-func newMockStreamerStream(action func(chan []Metric, time.Duration)) *mockStreamer {
+func newMockStreamerStream(action func(chan []Metric, time.Duration, []Metric)) *mockStreamer {
 	return &mockStreamer{action: action}
 }
 
-func (mc *mockStreamer) doAction(t time.Duration) {
-	go mc.action(mc.outMetric, t)
+func (mc *mockStreamer) doAction(t time.Duration, mts []Metric) {
+	go mc.action(mc.outMetric, t, mts)
 }
 func (mc *mockStreamer) GetMetricTypes(cfg Config) ([]Metric, error) {
 	if mc.err != nil {

--- a/v1/plugin/stream_collector_proxy.go
+++ b/v1/plugin/stream_collector_proxy.go
@@ -1,114 +1,44 @@
 package plugin
 
 import (
+	"errors"
 	"fmt"
+	"time"
 
 	"golang.org/x/net/context"
 
 	"github.com/intelsdi-x/snap-plugin-lib-go/v1/plugin/rpc"
 )
 
+const (
+	defaultMaxCollectDuration = 10 * time.Second
+	defaultMaxMetricsBuffer   = 0
+)
+
 type StreamProxy struct {
 	pluginProxy
-
 	plugin StreamCollector
+
+	// maxMetricsBuffer is the maximum number of metrics the plugin is buffering before sending metrics.
+	// Defaults to zero what means send metrics immediately.
+	maxMetricsBuffer int64
+
+	// maxCollectionDuration sets the maximum duration (always greater than 0s) between collections before metrics are sent.
+	// Defaults to 10s what means that after 10 seconds no new metrics are received, the plugin should send
+	// whatever data it has in the buffer instead of waiting longer.
+	maxCollectDuration time.Duration
 }
 
-func (c *StreamProxy) StreamMetrics(stream rpc.StreamCollector_StreamMetricsServer) error {
-	// Error channel where we will forward plugin errors to snap where it
-	// can report/handle them.
-	errChan := make(chan string)
-	// Metrics into the plugin from snap.
-	inChan := make(chan []Metric)
-	// Metrics out of the plugin into snap.
-	outChan := make(chan []Metric)
-	err := c.plugin.StreamMetrics(inChan, outChan, errChan)
-	if err != nil {
-		return err
-	}
-	go metricSend(c.plugin, outChan, stream)
-	go errorSend(c.plugin, errChan, stream)
-	streamRecv(c.plugin, inChan, stream)
-	return nil
-}
-
-func errorSend(
-	plugin StreamCollector,
-	ch chan string,
-	s rpc.StreamCollector_StreamMetricsServer) {
-	for r := range ch {
-		reply := &rpc.CollectReply{
-			Error: &rpc.ErrReply{Error: r},
-		}
-		if err := s.Send(reply); err != nil {
-			fmt.Println(err.Error())
-		}
-
-	}
-}
-
-func metricSend(
-	plugin StreamCollector,
-	ch chan []Metric,
-	s rpc.StreamCollector_StreamMetricsServer) {
-	for r := range ch {
-		mts := []*rpc.Metric{}
-		for _, mt := range r {
-			metric, err := toProtoMetric(mt)
-			if err != nil {
-				fmt.Println(err.Error())
-			}
-			mts = append(mts, metric)
-		}
-		reply := &rpc.CollectReply{
-			Metrics_Reply: &rpc.MetricsReply{Metrics: mts},
-		}
-		if err := s.Send(reply); err != nil {
-			fmt.Println(err.Error())
-		}
-	}
-
-}
-
-func streamRecv(
-	plugin StreamCollector,
-	ch chan []Metric,
-	s rpc.StreamCollector_StreamMetricsServer) {
-
-	for {
-		s, err := s.Recv()
-		if err != nil {
-			fmt.Println(err)
-			continue
-		}
-		if s != nil {
-			if s.Metrics_Arg != nil {
-				metrics := []Metric{}
-				for _, mt := range s.Metrics_Arg.Metrics {
-					metric := fromProtoMetric(mt)
-					metrics = append(metrics, metric)
-				}
-				ch <- metrics
-			}
-		}
-	}
-}
-
-func (c *StreamProxy) SetConfig(context.Context, *rpc.ConfigMap) (*rpc.ErrReply, error) {
-	return nil, nil
-}
-
-func (c *StreamProxy) GetMetricTypes(ctx context.Context, arg *rpc.GetMetricTypesArg) (*rpc.MetricsReply, error) {
+func (p *StreamProxy) GetMetricTypes(ctx context.Context, arg *rpc.GetMetricTypesArg) (*rpc.MetricsReply, error) {
 	cfg := fromProtoConfig(arg.Config)
 
-	r, err := c.plugin.GetMetricTypes(cfg)
+	r, err := p.plugin.GetMetricTypes(cfg)
 	if err != nil {
 		return nil, err
 	}
 	metrics := []*rpc.Metric{}
 	for _, mt := range r {
-		// We can ignore this error since we are not returning data from
-		// GetMetricTypes.
+		// We can ignore this error since we are not returning data from GetMetricTypes.
 		metric, _ := toProtoMetric(mt)
 		metrics = append(metrics, metric)
 	}
@@ -116,4 +46,134 @@ func (c *StreamProxy) GetMetricTypes(ctx context.Context, arg *rpc.GetMetricType
 		Metrics: metrics,
 	}
 	return reply, nil
+}
+
+func (p *StreamProxy) StreamMetrics(stream rpc.StreamCollector_StreamMetricsServer) error {
+	if stream == nil {
+		return errors.New("Stream metrics server is nil")
+	}
+
+	// Error channel where we will forward plugin errors to snap where it
+	// can report/handle them.
+	errChan := make(chan string)
+	// Metrics into the plugin from snap.
+	inChan := make(chan []Metric)
+	// Metrics out of the plugin into snap.
+	outChan := make(chan []Metric)
+
+	err := p.plugin.StreamMetrics(inChan, outChan, errChan)
+	if err != nil {
+		return err
+	}
+
+	go p.metricSend(outChan, stream)
+	go p.errorSend(errChan, stream)
+	p.streamRecv(inChan, stream)
+
+	return nil
+}
+
+func (p *StreamProxy) SetConfig(context.Context, *rpc.ConfigMap) (*rpc.ErrReply, error) {
+	return nil, nil
+}
+
+func (p *StreamProxy) errorSend(errChan chan string, stream rpc.StreamCollector_StreamMetricsServer) {
+	for r := range errChan {
+		reply := &rpc.CollectReply{
+			Error: &rpc.ErrReply{Error: r},
+		}
+		if err := stream.Send(reply); err != nil {
+			fmt.Println(err.Error())
+		}
+	}
+}
+
+func (p *StreamProxy) metricSend(ch chan []Metric, stream rpc.StreamCollector_StreamMetricsServer) {
+	metrics := []*rpc.Metric{}
+
+	for {
+		select {
+		case mts := <-ch:
+			if len(mts) == 0 {
+				break
+			}
+
+			for _, mt := range mts {
+				metric, err := toProtoMetric(mt)
+				if err != nil {
+					fmt.Println(err.Error())
+					break
+				}
+				metrics = append(metrics, metric)
+
+				// send metrics if maxMetricsBuffer is reached
+				// (notice it is only possible for maxMetricsBuffer greater than 0)
+				if p.maxMetricsBuffer == int64(len(metrics)) {
+					sendReply(metrics, stream)
+					metrics = []*rpc.Metric{}
+				}
+			}
+
+			// send all available metrics immediately for maxMetricsBuffer is 0 (defaults)
+			if p.maxMetricsBuffer == 0 {
+				sendReply(metrics, stream)
+				metrics = []*rpc.Metric{}
+			}
+		case <-time.After(p.maxCollectDuration):
+			// send metrics if maxCollectDuration is reached
+			sendReply(metrics, stream)
+			metrics = []*rpc.Metric{}
+
+		}
+	}
+}
+
+func (p *StreamProxy) streamRecv(ch chan []Metric, stream rpc.StreamCollector_StreamMetricsServer) {
+	for {
+		s, err := stream.Recv()
+		if err != nil {
+			fmt.Println(err)
+			continue
+		}
+		if s != nil {
+			if s.MaxMetricsBuffer > 0 {
+				p.setMaxMetricsBuffer(s.MaxMetricsBuffer)
+			}
+			if s.MaxCollectDuration > 0 {
+				p.setMaxCollectDuration(time.Duration(s.MaxCollectDuration))
+			}
+			if s.Metrics_Arg != nil {
+				metrics := []Metric{}
+				for _, mt := range s.Metrics_Arg.Metrics {
+					metric := fromProtoMetric(mt)
+					metrics = append(metrics, metric)
+				}
+				// send requested metrics to be collected into the stream plugin
+				ch <- metrics
+			}
+		}
+	}
+}
+
+func (p *StreamProxy) setMaxCollectDuration(d time.Duration) {
+	p.maxCollectDuration = d
+}
+
+func (p *StreamProxy) setMaxMetricsBuffer(i int64) {
+	p.maxMetricsBuffer = i
+}
+
+func sendReply(metrics []*rpc.Metric, stream rpc.StreamCollector_StreamMetricsServer) {
+	if len(metrics) == 0 {
+		fmt.Println("No metrics available to send")
+		return
+	}
+
+	reply := &rpc.CollectReply{
+		Metrics_Reply: &rpc.MetricsReply{Metrics: metrics},
+	}
+
+	if err := stream.Send(reply); err != nil {
+		fmt.Println(err.Error())
+	}
 }


### PR DESCRIPTION
### Summary of changes:
 - Added support for configuring a streaming collector based on passed in task manifest the following params: `max-metrics-buffer` and `max-collect-duration`

### Details
In the streaming proxy the MaxMetricsBuffer and MaxCollectDuration will control when metrics are sent down the (grpc) stream. Metrics will be sent when the MaxCollectDuration is exceeded or the MaxMetricsBuffer is reached. 

a) **default behavior** (`maxMetricsBuffer=0` and `maxCollectDuration=10s`)
The default behavior is **sending a batch of received metrics from a plugin immediately** to Snap. 

If there is no metrics streamed from the plugin for 10s (determined by `maxCollectDuration`) , `sendReply()` will be called to send a reply containing all already available metrics in buffer. However, in this specific case, the buffer will be empty (because metrics was sent immediately), so it comes down to return a log:
```
DEBU[2017-04-12T20:34:09+02:00] No metrics available to send  _module=plugin-exec io=stdout plugin=test-rand-streamer
```
 👉 see [v1/plugin/stream_collector_proxy.go#L122](https://github.com/intelsdi-x/snap-plugin-lib-go/pull/77/files#diff-aa6fc80eb3b8c2400af503a0443c72b7R122) 
👉 see [v1/plugin/stream_collector_proxy.go#L168](https://github.com/intelsdi-x/snap-plugin-lib-go/pull/77/files#diff-aa6fc80eb3b8c2400af503a0443c72b7R168)

**Notice** that if maxMetricsBuffer equals to the number of metrics received in a single batch, we get also default behavior and metrics will be send immediatelly (no buffering mechanism at all)

b) **metrics aggregation**
In many cases, this default behavior will not be efficient and some amount of aggregation will be needed - it might be achieved by setting maxMetricsBuffer greater than the number of metrics received in a single batch. This mechanism reduces the number of sent replies. 

c) **metrics splitting**
There is possible to obtain opposite behavior to aggregation when `maxMetricsBuffer` is smaller than the number of metrics received in a single batch. Of course, it would be propably rather used than aggregation, however it possible to do such thing. 

For example, set `maxMetricsBuffer=1` to be sure, that in a reply there will be only one metric.

### Instruction how to check this PR
- build snap-plugin-lib-go (use `make`)
- build snap-plugin-collector-stream-rand 
    - `$ cd snap-plugin-lib-go/examples/streaming`
    - `$ go build -o snap-plugin-collector-stream-rand main.go`
- load snap-plugin-collector-stream-rand and e.g. file publisher
- create a task: 
    - `curl -vX POST localhost:8181/v1/tasks -d @task_manifest.json --header "Content-Type: application/json"`

### Considered scenarios:
Used snap-plugin-collector-stream-rand which exposes 3 metrics

a) influence of `maxMetricsBuffer`:

No.         |  MaxMetricsBuffer |  Behavior
----------|---------------------|---------------
1  |  0 (default)  |  Send an available metric(s) immediately
2  |  4   | Aggregation: send 4 metrics (3 from the previous batch + 1 from the current one). If there are some remaining metrics from a batch, they will be sent in the next cycle
3  |  2  |  Splitting: send 2 metrics (2 from the current batch), The next 1 remaining metric from the current batch will be sent in the next cycle

b) influence of `maxCollectDuration`: 
If for X duration there is no new batch of metrics received from plugin, send a reply with whatever metrics it has in the buffer instead of waiting longer.If there is no metrics in buffer, return log "No metrics avaliable to send".

### Tests done:
- manual tests
- small tests

cc: @intelsdi-x/snap-maintainers 

---------------------------------------------------------------------------------------------------------------
### Done tests with stream-rand collector:
#### Test 1: Both of params are not provided in task manifest
Task manifest:
```json
{
    "version": 1,
    "schedule": {
        "type": "streaming"
    },
 "start": true,
  "max-failures": 10,
    "workflow": {
        "collect": {
            "metrics": {
                "/random/integer": {},
                "/random/string": {},
                "/random/float": {}
            },
            "publish": [
            {
                "plugin_name": "file",
                "config": {
                      "file": "/tmp/snap_streaming_case1"
                }
             }
           ]
        }
    }
}
```
Result:
Available metrics are sent immediately
![image](https://cloud.githubusercontent.com/assets/11335874/24778572/a55c00ec-1b2b-11e7-8bc3-a1658a1052d5.png)


#### Test 2: Provided non-zeroed `max-metrics-buffer` greater than 3
```json
{
    "version": 1,
    "schedule": {
        "type": "streaming"
    },
 "start": true,
  "max-failures": 10,
  "max-collect-duration": "10s",
  "max-metrics-buffer": 4,
  [...]
}
```


Result:
Streamed metrics will be buffered until maxMetricsBuffer = 4 is reached ->  4 metrics is expected to receive.

![image](https://cloud.githubusercontent.com/assets/11335874/24779190/fcf5521a-1b2e-11e7-882e-bbd4882a3773.png)

#### Test 3: Provided non-zeroed `max-metrics-buffer` smaller than 3
```json
{
    "version": 1,
    "schedule": {
        "type": "streaming"
    },
 "start": true,
  "max-failures": 10,
  "max-collect-duration": "10s",
  "max-metrics-buffer": 2,
  [...]
}
```
Result:
Streamed metrics will be splitted and 2 metrics is expected to receive from the current batch. 

![image](https://cloud.githubusercontent.com/assets/11335874/24975807/47bda21a-1fc7-11e7-8780-3d97f53232cd.png)

#### Test 4: Exceeding the maxCollectDuration 
Notice that stream-rand plugin streams metrics in interval=rand(10), so set maxCollectDuration to 5s seems to be resonable to tests such scenario
```json
  "max-collect-duration": "5s",
  "max-metrics-buffer": 7,
```
Results
Timeout to collect duration is 5s, so if no new batch of metrics received for 5s, reply with available metrics will be sent instead of waiting longer. As the results, the count of sending metrics might be various.


