### PR TITLE
Support for stand alone plugin

### DIFF
--- a/v1/plugin/flags.go
+++ b/v1/plugin/flags.go
@@ -5,7 +5,6 @@ import "github.com/urfave/cli"
 var (
 	flConfig = cli.StringFlag{
 		Name:        "config",
-		Value:       "",
 		Usage:       "config file to use",
 		Destination: &configIn,
 	}
@@ -15,14 +14,12 @@ var (
 	flPort = cli.StringFlag{
 		Name:        "port",
 		Usage:       "port to listen on",
-		Value:       "0",
 		Destination: &arg.ListenPort,
 	}
 	// If PingTimeoutDuration was provided we set it
 	flPingTimeout = cli.DurationFlag{
 		Name:        "pingTimeout",
 		Usage:       "how much time must elapse before a lack of Ping results in a timeout",
-		Value:       PingTimeoutDurationDefault,
 		Destination: &arg.PingTimeoutDuration,
 	}
 	flPprof = cli.BoolFlag{
@@ -38,13 +35,21 @@ var (
 	flCertPath = cli.StringFlag{
 		Name:        "certPath",
 		Usage:       "necessary to provide when TLS enabled",
-		Value:       "",
 		Destination: &arg.CertPath,
 	}
 	flKeyPath = cli.StringFlag{
 		Name:        "keyPath",
 		Usage:       "necessary to provide when TLS enabled",
-		Value:       "",
 		Destination: &arg.KeyPath,
+	}
+	flStandAlone = cli.BoolFlag{
+		Name:        "standAlone",
+		Usage:       "enable stand alone plugin",
+		Destination: &standAlone,
+	}
+	flHttpPort = cli.IntFlag{
+		Name:        "httpPort",
+		Usage:       "specify http port when standAlone is set",
+		Destination: &httpPort,
 	}
 )

--- a/v1/plugin/plugin_proxy.go
+++ b/v1/plugin/plugin_proxy.go
@@ -33,8 +33,7 @@ import (
 
 var (
 	// Timeout settings
-	// How much time must elapse before a lack of Ping results in a timeout
-	PingTimeoutDurationDefault = time.Millisecond * 1500
+
 	// How many successive PingTimeouts must occur to equal a failure.
 	PingTimeoutLimit = 3
 )
@@ -62,7 +61,7 @@ func newPluginProxy(plugin Plugin) *pluginProxy {
 func defaultPluginProxyCtor(plugin Plugin) *pluginProxy {
 	return &pluginProxy{
 		plugin:              plugin,
-		PingTimeoutDuration: PingTimeoutDurationDefault,
+		PingTimeoutDuration: arg.PingTimeoutDuration,
 		halt:                make(chan struct{}),
 	}
 }

--- a/v1/plugin/session.go
+++ b/v1/plugin/session.go
@@ -10,15 +10,18 @@ import (
 
 	"net/http/pprof"
 
+	logger "github.com/Sirupsen/logrus"
 	"github.com/julienschmidt/httprouter"
 )
 
 var (
-	pprofPort = "0"
-	configIn  = ""
-	arg       = Arg{
+	pprofPort  = "0"
+	configIn   = ""
+	standAlone = false
+	httpPort   = 0
+	arg        = Arg{
 		LogLevel:            uint8(2),
-		PingTimeoutDuration: PingTimeoutDurationDefault,
+		PingTimeoutDuration: time.Millisecond * 1500,
 		ListenPort:          "0",
 		Pprof:               false,
 		CertPath:            "",
@@ -58,7 +61,11 @@ func getArgs() (*Arg, error) {
 	if len(osArgs) > 1 && osArgs[1] != "" {
 		paramStr = osArgs[1]
 	}
-	json.Unmarshal([]byte(paramStr), &arg)
+	err := json.Unmarshal([]byte(paramStr), &arg)
+	logger.Errorf("!!!!!!!!! timeout: %v", arg.PingTimeoutDuration)
+
+	logger.Errorf("!!!!!!!!! err=%v", err)
+
 	if arg.Pprof {
 		return &arg, getPort()
 	}


### PR DESCRIPTION
  Add support for standalone plugin:

    - Add bool flag for standAlone and httpPort for selecting which port
    - Go routine for creating http server

Attention: This PR will land against the stand-alone-merge-diagnostics branch