### PR TITLE
Fix setting root CA certificate for TLS clients

### DIFF
--- a/v1/plugin/meta.go
+++ b/v1/plugin/meta.go
@@ -111,6 +111,7 @@ type meta struct {
 	CertPath         string
 	KeyPath          string
 	TLSEnabled       bool
+	RootCertPaths    string
 }
 
 // newMeta sets defaults, applies options, and then returns a meta struct

--- a/v1/plugin/session.go
+++ b/v1/plugin/session.go
@@ -37,6 +37,9 @@ type Arg struct {
 	// Path to TLS private key file for a TLS server
 	KeyPath string
 
+	// Paths to root certificates
+	RootCertPaths string
+
 	// Flag requesting server to establish TLS channel
 	TLSEnabled bool
 }

--- a/v1/plugin/tls_test.go
+++ b/v1/plugin/tls_test.go
@@ -1,4 +1,4 @@
-// +build medium
+// +build medium small
 
 /*
 http://www.apache.org/licenses/LICENSE-2.0.txt


### PR DESCRIPTION
- fixes #82,
- plugins are now accepting another run-time argument, RootCertPaths;
- ... being a list of fs paths (to directory or file), this enables plugins to use explicitly specified root certificates to validate client TLS certificates.
- to test this feature just add another argument to invocation of plugin binary, e.g.: `"RootCertPaths":"/tmp/first-root.crt:/tmp/second-root.crt:/tmp/many-roots-dir/"`

**Tests executed**
* developer tests,
* unit tests available in source tree,
* added unit tests to cover new functionality.