### PR TITLE
Adds standalone and diagnostic modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,40 @@ A Snap plugin is a program that responds to a set of well defined [gRPC](http://
 You will find [example plugins](examples) that cover the basics for writing collector, processor, and publisher plugins in the examples folder.
 
 
+## Snap Diagnostics
+Snap plugins using plugin-lib-go can be run independent of Snap to show their current running diagnostics. This diagnostic information includes:
+* Warning if dependencies not met
+* Config policy
+    * Warning if config items required and not provided
+* Collectable metrics
+* Runtime details
+    * Plugin version
+    * RPC type and version
+    * OS, architecture
+    * Golang version
+* How long it took to run each of these diagnostics
 
+### Running Diagnostics
+Running plugin diagnostics is easy! Simply build the plugin, then run the executable `$./build/${GOOS}/${GOARCH}/<plugin binary>`. When ran on its own, it will show a warning if a config is required for the plugin to load. 
+
+### Global Flags
+For specific details and to see all the options when running, run the plugin with the `-help` flag. The flag options are:
+```
+GLOBAL OPTIONS:
+   --config value            config to use in JSON format
+   --port value              port GRPC will listen on
+   --pprof                   enable pprof
+   --tls                     enable TLS
+   --cert-path value         necessary to provide when TLS enabled
+   --key-path value          necessary to provide when TLS enabled
+   --root-cert-paths value   root paths separated by ':'
+   --stand-alone             enable stand alone plugin
+   --stand-alone-port value  specify http port when stand-alone is set (default: 8181)
+   --log-level value         log level - 0:panic 1:fatal 2:error 3:warn 4:info 5:debug (default: 2)
+   --required-config         Plugin requires config passed in
+   --help, -h                show help
+   --version, -v             print the version
+```
+
+### Config flag
+When `-config` is set, it expects a parameter in the form of a JSON. This is of the form `'{}'`. An example config is: `-config '{\"key\":\"kelly\", \"spirit-animal\":\"coatimundi\"}'`.

--- a/examples/snap-plugin-collector-rand/README.md
+++ b/examples/snap-plugin-collector-rand/README.md
@@ -140,3 +140,15 @@ package rand
 You've made a plugin! Now it's time to share it. Create a release by following these [steps](https://help.github.com/articles/creating-releases/). We recommend that your release version match your plugin version, see example [here](https://github.com/intelsdi-x/snap-plugin-lib-go/blob/master/examples/snap-plugin-collector-rand/main.go#L29).
 
 Don't forget to announce your plugin release on [slack](https://intelsdi-x.herokuapp.com/) and get your plugin added to the [Plugin Catalog](https://github.com/intelsdi-x/snap/blob/master/docs/PLUGIN_CATALOG.md)!
+
+## Notice
+This plugin is also used for testing snap-plugin-lib-go. For that reason, we have added some additional capabilities to it for testing the following situations:
+- mock situation when a plugin requires a config to load
+  - **How to test:**
+When running plugin set the `-required-config` flag. Ex: `./snap-plugin-collector-rand -required-config`
+When this is set, the plugin will expect you to pass in a config item with the key `value`. If you don't pass in a config item or if that config doesn't contain the `value` key, an error will be thrown saying missing config item. Example: `./snap-plugin-collector-rand -required-config -config '{"value":"something"}'`
+
+- mock situation when a plugin does not have required dependencies
+  - **How to test:**
+When running the plugin, pass the `depsReq` key in through the config. Example: `./snap-plugin-collector-rand -required-config -config '{"depsReq":true}'`
+This will always throw an error, as it is simply testing how the plugin-lib handles the error when thrown. 

--- a/glide.yaml
+++ b/glide.yaml
@@ -41,3 +41,5 @@ import:
   - naming
   - peer
   - transport
+- package: github.com/Sirupsen/logrus
+  version: ^0.11.5

--- a/v1/plugin/collector_proxy_test.go
+++ b/v1/plugin/collector_proxy_test.go
@@ -46,8 +46,8 @@ func TestGetMetricTypes(t *testing.T) {
 			for _, m := range r.GetMetrics() {
 				tm := fromProtoMetric(m)
 				idx := fmt.Sprintf("%s.%d", tm.Namespace, tm.Version)
-				So(tm.Namespace.Strings(), ShouldResemble, metricMap[idx].Namespace.Strings())
-				So(tm.Tags, ShouldEqual, metricMap[idx].Tags)
+				So(tm.Namespace.Strings(), ShouldResemble, getMockMetricDataMap()[idx].Namespace.Strings())
+				So(tm.Tags, ShouldResemble, getMockMetricDataMap()[idx].Tags)
 			}
 		})
 		Convey("invalid metric types", func() {

--- a/v1/plugin/flags.go
+++ b/v1/plugin/flags.go
@@ -1,0 +1,56 @@
+package plugin
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/urfave/cli"
+)
+
+var (
+	flConfig = cli.StringFlag{
+		Name:  "config",
+		Usage: "config to use in JSON format",
+	}
+	// If no port was provided we let the OS select a port for us.
+	// This is safe as address is returned in the Response and keep
+	// alive prevents unattended plugins.
+	flPort = cli.StringFlag{
+		Name:  "port",
+		Usage: "port GRPC will listen on",
+	}
+	flLogLevel = cli.IntFlag{
+		Name:  "log-level",
+		Usage: "log level - 0:panic 1:fatal 2:error 3:warn 4:info 5:debug",
+		Value: 2,
+	}
+	flPprof = cli.BoolFlag{
+		Name:  "pprof",
+		Usage: "enable pprof",
+	}
+	flTLS = cli.BoolFlag{
+		Name:  "tls",
+		Usage: "enable TLS",
+	}
+	flCertPath = cli.StringFlag{
+		Name:  "cert-path",
+		Usage: "necessary to provide when TLS enabled",
+	}
+	flKeyPath = cli.StringFlag{
+		Name:  "key-path",
+		Usage: "necessary to provide when TLS enabled",
+	}
+	flRootCertPaths = cli.StringFlag{
+		Name:  "root-cert-paths",
+		Usage: fmt.Sprintf("root paths separated by '%c'", filepath.ListSeparator),
+	}
+	flStandAlone = cli.BoolFlag{
+		Name:  "stand-alone",
+		Usage: "enable stand alone plugin",
+	}
+	flHTTPPort = cli.IntFlag{
+		Name:  "stand-alone-port",
+		Usage: "specify http port when stand-alone is set",
+		Value: 8181,
+	}
+)

--- a/v1/plugin/grpc_test.go
+++ b/v1/plugin/grpc_test.go
@@ -24,6 +24,7 @@ package plugin
 import (
 	"fmt"
 	"net"
+	"os"
 	"reflect"
 	"strings"
 	"sync"
@@ -36,6 +37,19 @@ import (
 	"github.com/intelsdi-x/snap-plugin-lib-go/v1/plugin/rpc"
 	. "github.com/smartystreets/goconvey/convey"
 )
+
+func init() {
+	// Filter out go test flags
+	getOSArgs = func() []string {
+		args := []string{}
+		for _, v := range os.Args {
+			if !strings.HasPrefix(v, "-test") {
+				args = append(args, v)
+			}
+		}
+		return args
+	}
+}
 
 const GrpcTimeoutDefault = 2 * time.Second
 

--- a/v1/plugin/meta.go
+++ b/v1/plugin/meta.go
@@ -75,7 +75,7 @@ func CacheTTL(t time.Duration) MetaOpt {
 // metaRPCType sets the metaRPCType for the meta object. Used only internally.
 func rpcType(typ metaRPCType) MetaOpt {
 	return func(m *meta) {
-		m.RPCType = int(typ)
+		m.RPCType = typ
 	}
 }
 
@@ -94,13 +94,24 @@ const (
 	gRPCStream             = 3
 )
 
+func (t metaRPCType) String() string {
+	switch t {
+	case gRPC:
+		return "gRPC"
+	case gRPCStream:
+		return "streaming gRPC"
+	default:
+		return "unknown"
+	}
+}
+
 // meta is the metadata for a plugin
 type meta struct {
 	// A plugin's unique identifier is type:name:version.
 	Type       pluginType
 	Name       string
 	Version    int
-	RPCType    int
+	RPCType    metaRPCType
 	RPCVersion int
 
 	ConcurrencyCount int
@@ -122,8 +133,8 @@ func newMeta(plType pluginType, name string, version int, opts ...MetaOpt) *meta
 		Type:             plType,
 		ConcurrencyCount: defaultConcurrencyCount,
 		RoutingStrategy:  LRURouter,
-		RPCType:          2, // GRPC type
-		RPCVersion:       1, // This is v1 lib
+		RPCType:          gRPC, // GRPC type
+		RPCVersion:       1,    // This is v1 lib
 		// Unsecure is a legacy value not used for grpc, but needed to avoid
 		// calling SetKey needlessly.
 		Unsecure: true,

--- a/v1/plugin/meta_test.go
+++ b/v1/plugin/meta_test.go
@@ -50,15 +50,15 @@ func metaTestCases() []metaTestCase {
 	tc := []metaTestCase{
 		metaTestCase{
 			input:  *newMeta(collectorType, "fakeCollector", 0, ConcurrencyCount(0), Exclusive(false), RoutingStrategy(LRURouter), CacheTTL(time.Millisecond*0)),
-			output: meta{Type: collectorType, Name: "fakeCollector", Version: 0, ConcurrencyCount: 0, Exclusive: false, RoutingStrategy: 0, RPCType: 2, RPCVersion: 1, Unsecure: true, CacheTTL: time.Millisecond * 0},
+			output: meta{Type: collectorType, Name: "fakeCollector", Version: 0, ConcurrencyCount: 0, Exclusive: false, RoutingStrategy: 0, RPCType: gRPC, RPCVersion: 1, Unsecure: true, CacheTTL: time.Millisecond * 0},
 		},
 		metaTestCase{
 			input:  *newMeta(processorType, "fakeProcessor", 1, ConcurrencyCount(1), Exclusive(true), RoutingStrategy(StickyRouter), CacheTTL(time.Millisecond*1)),
-			output: meta{Type: processorType, Name: "fakeProcessor", Version: 1, ConcurrencyCount: 1, Exclusive: true, RoutingStrategy: 1, RPCType: 2, RPCVersion: 1, Unsecure: true, CacheTTL: time.Millisecond * 1},
+			output: meta{Type: processorType, Name: "fakeProcessor", Version: 1, ConcurrencyCount: 1, Exclusive: true, RoutingStrategy: 1, RPCType: gRPC, RPCVersion: 1, Unsecure: true, CacheTTL: time.Millisecond * 1},
 		},
 		metaTestCase{
 			input:  *newMeta(publisherType, "fakePublisher", 10, ConcurrencyCount(8), Exclusive(false), RoutingStrategy(ConfigBasedRouter), CacheTTL(time.Millisecond*1)),
-			output: meta{Type: publisherType, Name: "fakePublisher", Version: 10, ConcurrencyCount: 8, Exclusive: false, RoutingStrategy: 2, RPCType: 2, RPCVersion: 1, Unsecure: true, CacheTTL: time.Millisecond * 1},
+			output: meta{Type: publisherType, Name: "fakePublisher", Version: 10, ConcurrencyCount: 8, Exclusive: false, RoutingStrategy: 2, RPCType: gRPC, RPCVersion: 1, Unsecure: true, CacheTTL: time.Millisecond * 1},
 		},
 	}
 	return tc

--- a/v1/plugin/metric.go
+++ b/v1/plugin/metric.go
@@ -21,6 +21,7 @@ package plugin
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/intelsdi-x/snap-plugin-lib-go/v1/plugin/rpc"
@@ -266,6 +267,45 @@ func (n Namespace) Element(idx int) NamespaceElement {
 		return n[idx]
 	}
 	return NamespaceElement{}
+}
+
+// String returns the string representation of the namespace with "/" joining
+// the elements of the namespace.  A leading "/" is added.
+func (n Namespace) String() string {
+	ns := n.Strings()
+	s := n.getSeparator()
+	return s + strings.Join(ns, s)
+}
+
+// getSeparator returns the highest suitable separator from the nsPriorityList.
+// Otherwise the core separator is returned.
+func (n Namespace) getSeparator() string {
+	var nsPriorityList = []string{"/", "|", "%", ":", "-", ";", "_", "^", ">", "<", "+", "=", "&", "㊽", "Ä", "大", "小", "ᵹ", "☍", "ヒ"}
+	var Separator = "\U0001f422"
+
+	smap := map[string]bool{}
+
+	for _, s := range nsPriorityList {
+		smap[s] = false
+	}
+
+	for _, e := range n {
+		// look at each char
+		for _, r := range e.Value {
+			ch := fmt.Sprintf("%c", r)
+			if v, ok := smap[ch]; ok && !v {
+				smap[ch] = true
+			}
+		}
+	}
+
+	// Go through our separator list
+	for _, s := range nsPriorityList {
+		if v, ok := smap[s]; ok && !v {
+			return s
+		}
+	}
+	return Separator
 }
 
 // namespaceElement provides meta data related to the namespace.

--- a/v1/plugin/mocks_test.go
+++ b/v1/plugin/mocks_test.go
@@ -1,0 +1,257 @@
+// +build small medium
+
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2016 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugin
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/urfave/cli"
+)
+
+type mockPlugin struct {
+	err error
+}
+
+func newMockPlugin() *mockPlugin {
+	return &mockPlugin{}
+}
+
+func newMockErrPlugin() *mockPlugin {
+	return &mockPlugin{err: errors.New("error")}
+}
+
+type mockPublisher struct {
+	mockPlugin
+	err       error
+	doPublish func([]Metric, Config) error
+}
+
+func newMockPublisher() *mockPublisher {
+	return &mockPublisher{}
+}
+
+func newMockErrPublisher() *mockPublisher {
+	return &mockPublisher{err: errors.New("error")}
+}
+
+func (mpb *mockPublisher) Publish(mts []Metric, cfg Config) error {
+	if mpb.err != nil {
+		return mpb.err
+	}
+	if mpb.doPublish != nil {
+		return mpb.doPublish(mts, cfg)
+	}
+	return nil
+}
+
+func (mp *mockPlugin) GetConfigPolicy() (ConfigPolicy, error) {
+	if mp.err != nil {
+		return ConfigPolicy{}, errors.New("error")
+	}
+	cp := NewConfigPolicy()
+
+	cp.AddNewBoolRule([]string{"log"}, "logLevel", true, SetDefaultBool(true))
+	cp.AddNewBoolRule([]string{"cache"}, "cacheTime", true, SetDefaultBool(false))
+
+	cp.AddNewFloatRule([]string{"float"}, "low", true, SetDefaultFloat(32.1))
+	cp.AddNewFloatRule([]string{"cache"}, "high", true, SetDefaultFloat(2399.58))
+
+	cp.AddNewIntRule([]string{"xyz"}, "logLevel", false, SetDefaultInt(30))
+	cp.AddNewIntRule([]string{"abc"}, "cacheTime", true, SetDefaultInt(50))
+
+	cp.AddNewStringRule([]string{"log"}, "logLevel", true, SetDefaultString("123"))
+	cp.AddNewStringRule([]string{"cache"}, "cacheTime", true, SetDefaultString("tyty"))
+
+	return (*cp), nil
+}
+
+type mockStreamer struct {
+	mockPlugin
+	err                error
+	maxBuffer          int64
+	maxCollectDuration time.Duration
+	inMetric           chan []Metric
+	outMetric          chan []Metric
+	action             func(chan []Metric, time.Duration, []Metric)
+}
+
+func newMockStreamer() *mockStreamer {
+	return &mockStreamer{}
+}
+
+func newMockErrStreamer() *mockStreamer {
+	return &mockStreamer{err: errors.New("empty")}
+}
+
+func newMockStreamerStream(action func(chan []Metric, time.Duration, []Metric)) *mockStreamer {
+	return &mockStreamer{action: action}
+}
+
+func (mc *mockStreamer) doAction(t time.Duration, mts []Metric) {
+	go mc.action(mc.outMetric, t, mts)
+}
+func (mc *mockStreamer) GetMetricTypes(cfg Config) ([]Metric, error) {
+	if mc.err != nil {
+		return nil, errors.New("error")
+	}
+
+	mts := []Metric{}
+	for _, v := range getMockMetricDataMap() {
+		mts = append(mts, v)
+	}
+	return mts, nil
+}
+
+func (mc *mockStreamer) StreamMetrics(i chan []Metric, o chan []Metric, _ chan string) error {
+
+	if mc.err != nil {
+		return errors.New("error")
+	}
+	mc.inMetric = i
+	mc.outMetric = o
+	return nil
+}
+
+type mockCollector struct {
+	mockPlugin
+	err              error
+	doCollectMetrics func([]Metric) ([]Metric, error)
+	doGetMetricTypes func(Config) ([]Metric, error)
+}
+
+func newMockCollector() *mockCollector {
+	return &mockCollector{}
+}
+
+func newMockErrCollector() *mockCollector {
+	return &mockCollector{err: errors.New("empty")}
+}
+
+func (mc *mockCollector) GetMetricTypes(cfg Config) ([]Metric, error) {
+	if mc.err != nil {
+		return nil, errors.New("error")
+	}
+	if mc.doGetMetricTypes != nil {
+		return mc.doGetMetricTypes(cfg)
+	}
+	mts := []Metric{}
+	for _, v := range getMockMetricDataMap() {
+		mts = append(mts, v)
+	}
+	return mts, nil
+}
+
+func (mc *mockCollector) CollectMetrics(mts []Metric) ([]Metric, error) {
+	if mc.err != nil {
+		return nil, errors.New("error")
+	}
+	if mc.doCollectMetrics != nil {
+		return mc.doCollectMetrics(mts)
+	}
+	return mts, nil
+}
+
+type mockProcessor struct {
+	mockPlugin
+	err       error
+	doProcess func([]Metric, Config) ([]Metric, error)
+}
+
+func newMockProcessor() *mockProcessor {
+	return &mockProcessor{}
+}
+
+func newMockErrProcessor() *mockProcessor {
+	return &mockProcessor{err: errors.New("error")}
+}
+
+func (mp *mockProcessor) Process(mts []Metric, cfg Config) ([]Metric, error) {
+	if mp.err != nil {
+		return nil, mp.err
+	}
+	if mp.doProcess != nil {
+		return mp.doProcess(mts, cfg)
+	}
+	metrics := []Metric{}
+	for _, m := range mts {
+		if m.Version%2 == 0 {
+			metrics = append(metrics, m)
+		}
+	}
+	return metrics, nil
+}
+
+func getMockMetricDataMap() map[string]Metric {
+	mm := map[string]Metric{}
+	for i := 0; i < 10; i++ {
+		m := Metric{
+			Namespace: NewNamespace("a", "b", "c"),
+			Version:   int64(i),
+			Config:    map[string]interface{}{"key": 123},
+			Data:      i,
+			Tags:      map[string]string{fmt.Sprintf("tag%d", i): fmt.Sprintf("value%d", i)},
+			Unit:      "int",
+			Timestamp: time.Now(),
+		}
+		idx := fmt.Sprintf("%s.%d", m.Namespace, m.Version)
+		mm[idx] = m
+	}
+	return mm
+}
+
+type mockInputOutput struct {
+	mockArg         string
+	output          []string
+	doReadOSArg     func() string
+	doPrintOut      func(string)
+	prevInputOutput OSInputOutput
+}
+
+func (f *mockInputOutput) readOSArg() string {
+	return f.doReadOSArg()
+}
+
+func (f *mockInputOutput) printOut(data string) {
+	f.doPrintOut(data)
+}
+
+func (f *mockInputOutput) setContext(c *cli.Context) {
+
+}
+
+func (f *mockInputOutput) args() int {
+	return 1
+}
+
+func newMockInputOutput(prevInputOutput OSInputOutput) *mockInputOutput {
+	mock := mockInputOutput{mockArg: "{\"LogLevel\": 5}"}
+	mock.prevInputOutput = prevInputOutput
+	mock.doPrintOut = func(data string) {
+		mock.output = append(mock.output, data)
+	}
+	mock.doReadOSArg = func() string {
+		return mock.mockArg
+	}
+	return &mock
+}

--- a/v1/plugin/plugin.go
+++ b/v1/plugin/plugin.go
@@ -26,15 +26,57 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
+	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/urfave/cli"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
+	"text/tabwriter"
+
+	log "github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/snap-plugin-lib-go/v1/plugin/rpc"
 )
+
+var (
+	app     *cli.App
+	appArgs struct {
+		plugin  Plugin
+		name    string
+		version int
+		opts    []MetaOpt
+	}
+)
+
+func init() {
+	app = cli.NewApp()
+	app.Flags = []cli.Flag{
+		flConfig,
+		flPort,
+		flPprof,
+		flTLS,
+		flCertPath,
+		flKeyPath,
+		flRootCertPaths,
+		flStandAlone,
+		flHTTPPort,
+		flLogLevel,
+	}
+	app.Action = startPlugin
+}
+
+// AddFlag accepts a cli.Flag to the plugins standard flags.
+func AddFlag(flags ...cli.Flag) {
+	for _, f := range flags {
+		app.Flags = append(app.Flags, f)
+	}
+}
 
 // Plugin is the base plugin type. All plugins must implement GetConfigPolicy.
 type Plugin interface {
@@ -65,6 +107,8 @@ type Publisher interface {
 	Publish([]Metric, Config) error
 }
 
+var App *cli.App
+
 /*
  StreamCollector is a Collector that can send back metrics within configurable limits defined in task manifest.
  These limits might be determined by user by set a value of:
@@ -72,7 +116,6 @@ type Publisher interface {
   - `max-collect-duration`, default to 10s what means after 10s no new metrics are received, send a reply whatever data it has
   in buffer instead of waiting longer
 */
-
 type StreamCollector interface {
 	Plugin
 
@@ -91,6 +134,8 @@ type StreamCollector interface {
 	GetMetricTypes(Config) ([]Metric, error)
 }
 
+var getOSArgs = func() []string { return os.Args }
+
 // tlsServerSetup offers functions supporting TLS server setup
 type tlsServerSetup interface {
 	// makeTLSConfig delivers TLS config suitable to use for plugins, excluding
@@ -104,16 +149,51 @@ type tlsServerSetup interface {
 }
 
 // osInputOutput supports interactions with OS for the plugin lib
-type osInputOutput interface {
+type OSInputOutput interface {
 	// readOSArgs gets command line arguments passed to application
-	readOSArgs() []string
+	readOSArg() string
 	// printOut outputs given data to application standard output
 	printOut(data string)
+
+	args() int
+
+	setContext(c *cli.Context)
 }
 
 // standardInputOutput delivers standard implementation for OS
 // interactions
 type standardInputOutput struct {
+	context *cli.Context
+}
+
+// libInputOutput holds utility used for OS interactions
+var libInputOutput OSInputOutput = &standardInputOutput{}
+
+// readOSArgs implementation that returns application args passed by OS
+func (io *standardInputOutput) readOSArg() string {
+	if io.context != nil {
+		return io.context.Args().First()
+	}
+	if len(os.Args) > 0 {
+		return os.Args[0]
+	}
+	return ""
+}
+
+// printOut implementation that emits data into standard output
+func (io *standardInputOutput) printOut(data string) {
+	fmt.Println(data)
+}
+
+func (io *standardInputOutput) setContext(c *cli.Context) {
+	io.context = c
+}
+
+func (io *standardInputOutput) args() int {
+	if io.context != nil {
+		return io.context.NArg()
+	}
+	return 0
 }
 
 // tlsServerDefaultSetup provides default implementation for TLS setup routines
@@ -122,9 +202,6 @@ type tlsServerDefaultSetup struct {
 
 // tlsSetup holds TLS setup utility for plugin lib
 var tlsSetup tlsServerSetup = tlsServerDefaultSetup{}
-
-// libInputOutput holds utility used for OS interactions
-var libInputOutput osInputOutput = standardInputOutput{}
 
 // makeTLSConfig provides TLS configuraton template for plugins, setting
 // required verification of client cert and preferred server suites.
@@ -200,16 +277,6 @@ func (ts tlsServerDefaultSetup) loadRootCerts(certPaths []string) (rootCAs *x509
 	return rootCAs, nil
 }
 
-// readOSArgs implementation that returns application args passed by OS
-func (io standardInputOutput) readOSArgs() []string {
-	return os.Args
-}
-
-// printOut implementation that emits data into standard output
-func (io standardInputOutput) printOut(data string) {
-	fmt.Println(data)
-}
-
 // makeGRPCCredentials delivers credentials object suitable for setting up gRPC
 // server, with TLS optionally turned on.
 func makeGRPCCredentials(m *meta) (creds credentials.TransportCredentials, err error) {
@@ -254,14 +321,10 @@ func applySecurityArgsToMeta(m *meta, args *Arg) error {
 
 // buildGRPCServer configures and builds GRPC server ready to server a plugin
 // instance
-func buildGRPCServer(typeOfPlugin pluginType, name string, version int, opts ...MetaOpt) (server *grpc.Server, m *meta, err error) {
-	args, err := getArgs()
-	if err != nil {
-		return nil, nil, err
-	}
+func buildGRPCServer(typeOfPlugin pluginType, name string, version int, arg *Arg, opts ...MetaOpt) (server *grpc.Server, m *meta, err error) {
 	m = newMeta(typeOfPlugin, name, version, opts...)
 
-	if err := applySecurityArgsToMeta(m, args); err != nil {
+	if err := applySecurityArgsToMeta(m, arg); err != nil {
 		return nil, nil, err
 	}
 	creds, err := makeGRPCCredentials(m)
@@ -280,67 +343,76 @@ func buildGRPCServer(typeOfPlugin pluginType, name string, version int, opts ...
 // generates a response for the initial stdin / stdout handshake, and starts
 // the plugin's gRPC server.
 func StartCollector(plugin Collector, name string, version int, opts ...MetaOpt) int {
-	server, m, err := buildGRPCServer(collectorType, name, version, opts...)
+	appArgs.plugin = plugin
+	appArgs.name = name
+	appArgs.version = version
+	appArgs.opts = opts
+	app.Version = strconv.Itoa(version)
+	app.Usage = "a Snap collector"
+	err := app.Run(getOSArgs())
 	if err != nil {
-		panic(err)
+		log.WithFields(log.Fields{
+			"_block": "StartCollector",
+		}).Error(err)
+		return 1
 	}
-	proxy := &collectorProxy{
-		plugin:      plugin,
-		pluginProxy: *newPluginProxy(plugin),
-	}
-	rpc.RegisterCollectorServer(server, proxy)
-	return startPlugin(server, m, &proxy.pluginProxy)
+	return 0
 }
 
 // StartProcessor is given a Processor implementation and its metadata,
 // generates a response for the initial stdin / stdout handshake, and starts
 // the plugin's gRPC server.
 func StartProcessor(plugin Processor, name string, version int, opts ...MetaOpt) int {
-	server, m, err := buildGRPCServer(processorType, name, version, opts...)
+	appArgs.plugin = plugin
+	appArgs.name = name
+	appArgs.version = version
+	appArgs.opts = opts
+	app.Version = strconv.Itoa(version)
+	app.Usage = "a Snap processor"
+	err := app.Run(getOSArgs())
 	if err != nil {
-		panic(err)
+		log.Error(err)
+		return 1
 	}
-	proxy := &processorProxy{
-		plugin:      plugin,
-		pluginProxy: *newPluginProxy(plugin),
-	}
-	rpc.RegisterProcessorServer(server, proxy)
-	return startPlugin(server, m, &proxy.pluginProxy)
+	return 0
 }
 
 // StartPublisher is given a Publisher implementation and its metadata,
 // generates a response for the initial stdin / stdout handshake, and starts
 // the plugin's gRPC server.
 func StartPublisher(plugin Publisher, name string, version int, opts ...MetaOpt) int {
-	server, m, err := buildGRPCServer(publisherType, name, version, opts...)
+	appArgs.plugin = plugin
+	appArgs.name = name
+	appArgs.version = version
+	appArgs.opts = opts
+	app.Version = strconv.Itoa(version)
+	app.Usage = "a Snap publisher"
+	err := app.Run(getOSArgs())
 	if err != nil {
-		panic(err)
+		log.Error(err)
+		return 1
 	}
-	proxy := &publisherProxy{
-		plugin:      plugin,
-		pluginProxy: *newPluginProxy(plugin),
-	}
-	rpc.RegisterPublisherServer(server, proxy)
-	return startPlugin(server, m, &proxy.pluginProxy)
+	return 0
 }
 
 // StartStreamCollector is given a StreamCollector implementation and its metadata,
 // generates a response for the initial stdin / stdout handshake, and starts
 // the plugin's gRPC server.
 func StartStreamCollector(plugin StreamCollector, name string, version int, opts ...MetaOpt) int {
+	appArgs.plugin = plugin
+	appArgs.name = name
+	appArgs.version = version
+	//set gRPCStream as RPC type
 	opts = append(opts, rpcType(gRPCStream))
-	server, m, err := buildGRPCServer(collectorType, name, version, opts...)
+	appArgs.opts = opts
+	app.Version = strconv.Itoa(version)
+	app.Usage = "a Snap collector"
+	err := app.Run(getOSArgs())
 	if err != nil {
-		panic(err)
+		log.Error(err)
+		return 1
 	}
-	proxy := &StreamProxy{
-		plugin:             plugin,
-		pluginProxy:        *newPluginProxy(plugin),
-		maxCollectDuration: defaultMaxCollectDuration,
-		maxMetricsBuffer:   defaultMaxMetricsBuffer,
-	}
-	rpc.RegisterStreamCollectorServer(server, proxy)
-	return startPlugin(server, m, &proxy.pluginProxy)
+	return 0
 }
 
 type server interface {
@@ -356,39 +428,484 @@ type preamble struct {
 	ErrorMessage  string
 }
 
-func startPlugin(srv server, m *meta, p *pluginProxy) int {
-	l, err := net.Listen("tcp", ":"+listenPort)
+func startPlugin(c *cli.Context) error {
+	var (
+		server      *grpc.Server
+		meta        *meta
+		pluginProxy *pluginProxy
+	)
+	libInputOutput.setContext(c)
+	arg, err := processInput(c)
 	if err != nil {
-		panic("Unable to get open port")
+		return err
+	}
+	if lvl := c.Int("log-level"); lvl > arg.LogLevel {
+		log.SetLevel(log.Level(lvl))
+	} else {
+		log.SetLevel(log.Level(arg.LogLevel))
+	}
+	logger := log.WithFields(log.Fields{
+		"_block": "startPlugin",
+	})
+	switch plugin := appArgs.plugin.(type) {
+	case Collector:
+		proxy := &collectorProxy{
+			plugin:      plugin,
+			pluginProxy: *newPluginProxy(plugin),
+		}
+		pluginProxy = &proxy.pluginProxy
+		server, meta, err = buildGRPCServer(collectorType, appArgs.name, appArgs.version, arg, appArgs.opts...)
+		if err != nil {
+			return cli.NewExitError(err, 2)
+		}
+		rpc.RegisterCollectorServer(server, proxy)
+	case Processor:
+		proxy := &processorProxy{
+			plugin:      plugin,
+			pluginProxy: *newPluginProxy(plugin),
+		}
+		pluginProxy = &proxy.pluginProxy
+		server, meta, err = buildGRPCServer(processorType, appArgs.name, appArgs.version, arg, appArgs.opts...)
+		if err != nil {
+			return cli.NewExitError(err, 2)
+		}
+		rpc.RegisterProcessorServer(server, proxy)
+	case Publisher:
+		proxy := &publisherProxy{
+			plugin:      plugin,
+			pluginProxy: *newPluginProxy(plugin),
+		}
+		pluginProxy = &proxy.pluginProxy
+		server, meta, err = buildGRPCServer(publisherType, appArgs.name, appArgs.version, arg, appArgs.opts...)
+		if err != nil {
+			return cli.NewExitError(err, 2)
+		}
+		rpc.RegisterPublisherServer(server, proxy)
+	case StreamCollector:
+		proxy := &StreamProxy{
+			plugin:             plugin,
+			pluginProxy:        *newPluginProxy(plugin),
+			maxCollectDuration: defaultMaxCollectDuration,
+			maxMetricsBuffer:   defaultMaxMetricsBuffer,
+		}
+		pluginProxy = &proxy.pluginProxy
+		server, meta, err = buildGRPCServer(collectorType, appArgs.name, appArgs.version, arg, appArgs.opts...)
+		if err != nil {
+			return cli.NewExitError(err, 2)
+		}
+		rpc.RegisterStreamCollectorServer(server, proxy)
+	default:
+		logger.WithField("type", fmt.Sprintf("%T", plugin)).Fatal("Unknown plugin type")
+	}
+
+	if c.Bool("stand-alone") {
+		httpPort := c.Int("stand-alone-port")
+		preamble, err := printPreambleAndServe(server, meta, pluginProxy, arg.ListenPort, arg.Pprof)
+		if err != nil {
+			log.Error(err)
+			return err
+		}
+
+		go func() {
+			http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprintln(w, preamble)
+			})
+
+			listener, err := net.Listen("tcp", fmt.Sprintf(":%d", httpPort))
+			if err != nil {
+				log.WithFields(
+					log.Fields{
+						"port": httpPort,
+					},
+				).Fatal("Unable to get open port")
+			}
+			defer listener.Close()
+			fmt.Printf("Preamble URL: %v\n", listener.Addr().String())
+			err = http.Serve(listener, nil)
+			if err != nil {
+				log.Fatal(err)
+			}
+		}()
+		<-pluginProxy.halt
+
+	} else if libInputOutput.args() > 0 {
+		// snapteld is starting the plugin
+		// presumably with a single arg (valid json)
+		preamble, err := printPreambleAndServe(server, meta, pluginProxy, arg.ListenPort, arg.Pprof)
+		if err != nil {
+			log.Fatal(err)
+		}
+		libInputOutput.printOut(preamble)
+		go pluginProxy.HeartbeatWatch()
+		<-pluginProxy.halt
+
+	} else {
+		// no arguments provided - run and display diagnostics to the user
+		var config Config
+		if c.IsSet("config") {
+			err := json.Unmarshal([]byte(c.String("config")), &config)
+			if err != nil {
+				log.WithFields(log.Fields{
+					"error": err,
+				}).Error("unable to parse config")
+				return err
+			}
+		}
+
+		switch pluginProxy.plugin.(type) {
+		case Collector:
+			return showDiagnostics(*meta, pluginProxy, config)
+		case StreamCollector:
+			fmt.Println("Diagnostics not currently available for streaming collector plugins.")
+		case Processor:
+			fmt.Println("Diagnostics not currently available for processor plugins.")
+		case Publisher:
+			fmt.Println("Diagnostics not currently available for publisher plugins.")
+		}
+	}
+	return nil
+}
+
+func printPreambleAndServe(srv server, m *meta, p *pluginProxy, port string, isPprof bool) (string, error) {
+	l, err := net.Listen("tcp", fmt.Sprintf(":%v", port))
+	if err != nil {
+		return "", err
 	}
 	l.Close()
 
 	addr := fmt.Sprintf("127.0.0.1:%v", l.Addr().(*net.TCPAddr).Port)
 	lis, err := net.Listen("tcp", addr)
 	if err != nil {
-		// TODO(danielscottt): logging
-		panic(err)
+		return "", err
 	}
 	go func() {
 		err := srv.Serve(lis)
 		if err != nil {
-			panic(err)
+			log.Fatal(err)
 		}
 	}()
+	pprofAddr := "0"
+	if isPprof {
+		pprofAddr, err = startPprof()
+		if err != nil {
+			return "", err
+		}
+	}
 	resp := preamble{
 		Meta:          *m,
 		ListenAddress: addr,
 		Type:          m.Type,
-		PprofAddress:  pprofPort,
+		PprofAddress:  pprofAddr,
 		State:         0, // Hardcode success since panics on err
 	}
 	preambleJSON, err := json.Marshal(resp)
 	if err != nil {
-		panic(err)
+		return "", err
 	}
-	libInputOutput.printOut(string(preambleJSON))
-	go p.HeartbeatWatch()
-	// TODO(danielscottt): exit code
-	<-p.halt
-	return 0
+
+	return string(preambleJSON), nil
+}
+
+func showDiagnostics(m meta, p *pluginProxy, c Config) error {
+	defer timeTrack(time.Now(), "showDiagnostics")
+	printRuntimeDetails(m)
+	err := printConfigPolicy(p, c)
+	if err != nil {
+		return err
+	}
+
+	met, err := printMetricTypes(p, c)
+	if err != nil {
+		return err
+	}
+	err = printCollectMetrics(p, met)
+	if err != nil {
+		return err
+	}
+	printContactUs()
+	return nil
+
+}
+
+func printMetricTypes(p *pluginProxy, conf Config) ([]Metric, error) {
+	defer timeTrack(time.Now(), "printMetricTypes")
+	met, err := p.plugin.(Collector).GetMetricTypes(conf)
+	if err != nil {
+		return nil, fmt.Errorf("! Error in the call to GetMetricTypes: \n%v", err)
+	}
+	//apply any config passed in to met so that
+	//CollectMetrics can see the config for each metric
+	for i := range met {
+		met[i].Config = conf
+	}
+
+	fmt.Println("Metric catalog will be updated to include: ")
+	for _, j := range met {
+		fmt.Printf("    Namespace: %v \n", j.Namespace.String())
+	}
+	return met, nil
+}
+
+func printConfigPolicy(p *pluginProxy, conf Config) error {
+	defer timeTrack(time.Now(), "printConfigPolicy")
+	requiredConfigs := ""
+	cPolicy, err := p.plugin.(Collector).GetConfigPolicy()
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Config Policy:")
+	w := tabwriter.NewWriter(os.Stdout, 0, 8, 1, '\t', 0)
+	printFields(w, false, 0, "NAMESPACE", "KEY", "TYPE", "REQUIRED", "DEFAULT", "MINIMUM", "MAXIMUM")
+
+	requiredConfigs += printConfigPolicyStringRules(cPolicy, conf, w)
+	requiredConfigs += printConfigPolicyIntegerRules(cPolicy, conf, w)
+	requiredConfigs += printConfigPolicyFloatRules(cPolicy, conf, w)
+	requiredConfigs += printConfigPolicyBoolRules(cPolicy, conf, w)
+
+	w.Flush()
+	if requiredConfigs != "" {
+		requiredConfigs += "! Please provide config in form of: -config '{\"key\":\"kelly\", \"spirit-animal\":\"coatimundi\"}'\n"
+		err := fmt.Errorf(requiredConfigs)
+		return err
+	}
+
+	return nil
+}
+
+func printFields(tw *tabwriter.Writer, indent bool, width int, fields ...interface{}) {
+	var argArray []interface{}
+	if indent {
+		argArray = append(argArray, strings.Repeat(" ", width))
+	}
+	for i, field := range fields {
+		if field != nil {
+			argArray = append(argArray, field)
+		} else {
+			argArray = append(argArray, "")
+		}
+		if i < (len(fields) - 1) {
+			argArray = append(argArray, "\t")
+		}
+	}
+	fmt.Fprintln(tw, argArray...)
+}
+
+func stringInSlice(a string, list []string) (int, bool) {
+	for i, b := range list {
+		if b == a {
+			return i, true
+		}
+	}
+	return -1, false
+}
+
+func parseString(vals []string, name string, conf Config) (required string, minimum string, maximum string) {
+	//check if required
+	if _, okReq := stringInSlice("required:true", vals); okReq {
+		required = "true"
+	} else {
+		required = "false"
+	}
+
+	//check if has_min:true
+	if _, okMin := stringInSlice("has_min:true", vals); okMin {
+		//Check if minimum is specified, if not, default = 0
+		idxInArray := -1
+		valueAtIndex := ""
+		for i, b := range vals {
+			if strings.Contains(b, "minimum:") {
+				idxInArray = i
+				valueAtIndex = b
+			}
+		}
+		if idxInArray != -1 {
+			//parse val[idx] to get contents after :
+			idxOfColon := strings.Index(valueAtIndex, ":")
+			minimum = valueAtIndex[idxOfColon+1:]
+		} else {
+			minimum = "0"
+		}
+	}
+
+	//check if has_max:true
+	if _, okMax := stringInSlice("has_max:true", vals); okMax {
+		//Check if minimum is specified
+		idxInArray := -1
+		valueAtIndex := ""
+		for i, b := range vals {
+			if strings.Contains(b, "maximum:") {
+				idxInArray = i
+				valueAtIndex = b
+			}
+		}
+		if idxInArray != -1 {
+			//parse val[idx] to get contents after :
+			idxOfColon := strings.Index(valueAtIndex, ":")
+			maximum = valueAtIndex[idxOfColon+1:]
+		} else {
+			//No default max value
+		}
+	}
+
+	return required, minimum, maximum
+}
+
+func checkForMissingRequirements(vals []string, name string, conf Config) (requiredConfigs string) {
+	if _, okReq := stringInSlice("required:true", vals); okReq {
+		if _, ok := conf[name]; !ok {
+			requiredConfigs += "! Warning: \"" + name + "\" required by plugin and not provided in config \n"
+		}
+	}
+	return requiredConfigs
+}
+
+func printConfigPolicyStringRules(cPolicy ConfigPolicy, conf Config, w *tabwriter.Writer) (requiredConfigs string) {
+	if len(cPolicy.stringRules) > 0 {
+		for ns, v := range cPolicy.stringRules {
+			for key, val := range v.Rules {
+				defaultValue := ""
+				if val.HasDefault {
+					defaultValue = val.Default
+				}
+				if val.String() != "" {
+					vals := strings.Fields(val.String())
+					req, min, max := parseString(vals, ns, conf)
+					printFields(w, false, 0, ns, key, "string", req, defaultValue, min, max)
+
+					requiredConfigs += checkForMissingRequirements(vals, key, conf)
+				} else {
+					printFields(w, false, 0, ns, key, "string", "false", defaultValue, "", "")
+				}
+			}
+		}
+	}
+
+	return requiredConfigs
+}
+
+func printConfigPolicyIntegerRules(cPolicy ConfigPolicy, conf Config, w *tabwriter.Writer) (requiredConfigs string) {
+	if len(cPolicy.integerRules) > 0 {
+		for k, v := range cPolicy.integerRules {
+			for key, val := range v.Rules {
+				defaultValue := ""
+				if val.HasDefault {
+					defaultValue = strconv.FormatInt(val.Default, 10)
+				}
+				if val.String() != "" {
+					//parse info:
+					vals := strings.Fields(val.String())
+					req, min, max := parseString(vals, k, conf)
+					printFields(w, false, 0, k, key, "integer", req, defaultValue, min, max)
+
+					requiredConfigs += checkForMissingRequirements(vals, key, conf)
+				} else {
+					printFields(w, false, 0, k, key, "integer", "false", defaultValue, "", "")
+				}
+			}
+		}
+	}
+	return requiredConfigs
+}
+
+func printConfigPolicyFloatRules(cPolicy ConfigPolicy, conf Config, w *tabwriter.Writer) (requiredConfigs string) {
+	if len(cPolicy.floatRules) > 0 {
+		for k, v := range cPolicy.floatRules {
+			for key, val := range v.Rules {
+				defaultValue := ""
+				if val.HasDefault {
+					defaultValue = strconv.FormatFloat(val.Default, 'f', -1, 64)
+				}
+				if val.String() != "" {
+					//parse info:
+					vals := strings.Fields(val.String())
+					req, min, max := parseString(vals, k, conf)
+					printFields(w, false, 0, k, key, "float", req, defaultValue, min, max)
+
+					requiredConfigs += checkForMissingRequirements(vals, key, conf)
+				} else {
+					printFields(w, false, 0, k, key, "float", "false", defaultValue, "", "")
+				}
+			}
+		}
+	}
+	return requiredConfigs
+}
+
+func printConfigPolicyBoolRules(cPolicy ConfigPolicy, conf Config, w *tabwriter.Writer) (requiredConfigs string) {
+	if len(cPolicy.boolRules) > 0 {
+		for k, v := range cPolicy.boolRules {
+			for key, val := range v.Rules {
+				defaultValue := ""
+				if val.HasDefault {
+					defaultValue = strconv.FormatBool(val.Default)
+				}
+				if val.String() != "" {
+					//parse info:
+					vals := strings.Fields(val.String())
+					req, min, max := parseString(vals, k, conf)
+					printFields(w, false, 0, k, key, "bool", req, defaultValue, min, max)
+
+					requiredConfigs += checkForMissingRequirements(vals, key, conf)
+				} else {
+					printFields(w, false, 0, k, key, "bool", "false", defaultValue, "", "")
+				}
+			}
+		}
+	}
+	return requiredConfigs
+}
+
+func printCollectMetrics(p *pluginProxy, m []Metric) error {
+	defer timeTrack(time.Now(), "printCollectMetrics")
+	cltd, err := p.plugin.(Collector).CollectMetrics(m)
+	if err != nil {
+		return fmt.Errorf("! Error in the call to CollectMetrics. Please ensure your config contains any required fields mentioned in the error below. \n %v", err)
+	}
+	fmt.Println("Metrics that can be collected right now are: ")
+	for _, j := range cltd {
+		fmt.Printf("    Namespace: %-30v  Type: %-10T  Value: %v \n", j.Namespace, j.Data, j.Data)
+	}
+	return nil
+}
+
+func printRuntimeDetails(m meta) {
+	defer timeTrack(time.Now(), "printRuntimeDetails")
+	fmt.Printf("Runtime Details:\n    PluginName: %v, Version: %v \n    RPC Type: %v, RPC Version: %v \n", m.Name, m.Version, m.RPCType.String(), m.RPCVersion)
+	fmt.Printf("    Operating system: %v \n    Architecture: %v \n    Go version: %v \n", runtime.GOOS, runtime.GOARCH, runtime.Version())
+}
+
+func printContactUs() {
+	fmt.Print("Thank you for using this Snap plugin. If you have questions or are running \ninto errors, please contact us on Github (github.com/intelsdi-x/snap) or \nour Slack channel (intelsdi-x.herokuapp.com). \nThe repo for this plugin can be found: github.com/intelsdi-x/<plugin-name>. \nWhen submitting a new issue on Github, please include this diagnostic \nprint out so that we have a starting point for addressing your question. \nThank you. \n\n")
+}
+
+func timeTrack(start time.Time, name string) {
+	elapsed := time.Since(start)
+	fmt.Printf("%s took %s \n\n", name, elapsed)
+}
+
+func processInput(c *cli.Context) (*Arg, error) {
+	arg := &Arg{}
+	if c.IsSet("log-level") {
+		arg.LogLevel = c.Int("log-level")
+	}
+	if c.IsSet("port") {
+		arg.ListenPort = c.String("port")
+	}
+	if c.IsSet("pprof") {
+		arg.Pprof = c.Bool("pprof")
+	}
+	if c.IsSet("cert-path") {
+		arg.CertPath = c.String("cert-path")
+	}
+	if c.IsSet("key-path") {
+		arg.KeyPath = c.String("key-path")
+	}
+	if c.IsSet("root-cert-paths") {
+		arg.RootCertPaths = c.String("root-cert-paths")
+	}
+	if c.IsSet("tls") {
+		arg.TLSEnabled = true
+	}
+	return processArg(arg)
 }

--- a/v1/plugin/plugin_proxy.go
+++ b/v1/plugin/plugin_proxy.go
@@ -33,10 +33,13 @@ import (
 
 var (
 	// Timeout settings
-	// How much time must elapse before a lack of Ping results in a timeout
-	PingTimeoutDurationDefault = time.Millisecond * 1500
-	// How many successive PingTimeouts must occur to equal a failure.
+
+	// PingTimeoutLimit is the number of successively missed ping health
+	// checks which must occur before the plugin is stopped
 	PingTimeoutLimit = 3
+	// PingTimeoutDuration is the duration during which a ping healthcheck
+	// should be received
+	PingTimeoutDuration = 3 * time.Second
 )
 
 type pluginProxyConstructor func(Plugin) *pluginProxy
@@ -62,7 +65,7 @@ func newPluginProxy(plugin Plugin) *pluginProxy {
 func defaultPluginProxyCtor(plugin Plugin) *pluginProxy {
 	return &pluginProxy{
 		plugin:              plugin,
-		PingTimeoutDuration: PingTimeoutDurationDefault,
+		PingTimeoutDuration: PingTimeoutDuration,
 		halt:                make(chan struct{}),
 	}
 }

--- a/v1/plugin/publisher_proxy_test.go
+++ b/v1/plugin/publisher_proxy_test.go
@@ -59,7 +59,7 @@ func TestPublisher(t *testing.T) {
 func getTestData() ([]*rpc.Metric, error) {
 	input := []*rpc.Metric{}
 
-	mp := getMetricData()
+	mp := getMockMetricDataMap()
 	for _, v := range mp {
 		m, err := toProtoMetric(v)
 		if err != nil {


### PR DESCRIPTION
- [x] Refactor diagnostic output based on feedback from @IzabellaRaulin 
- [x] Enable overriding pprof and other args based on flags 
- All other feedback has been incorporated.

---
This PR builds on @kjlyon's work which added both standalone and diagnostic modes and @marcintao's commit that recently added TLS support which required the `flag` package.  

## Summary
* Removes dep on flag package in favor of using urfave/cli throughout
* Reworks path of execution to leverage the strength of the cli framework (urfave/cli)
    * During the libs `init` the cli.App is created and the function `startPlugin` is registered as the Action
    * Plugins continue to call their entry points `StartCollector`, `StartProcessor`, etc. which then dispatches to startPlugin by calling `app.Run(getOSArgs())`
* The recently added TLS work was largely unaffected


## The image below demonstrates 
* Displaying a plugins help
* Starting a plugin in stand-alone mode
* Starting a plugin provided a valid arg (json) 👈 the way snapteld starts a plugin
![img](https://www.dropbox.com/s/w7y2ug8toa46jp6/02.gif?raw=1)