### PR TITLE
Removed hardcoded version from GetMetricTypes

### DIFF
--- a/examples/snap-plugin-collector-rand-streaming/rand/rand.go
+++ b/examples/snap-plugin-collector-rand-streaming/rand/rand.go
@@ -146,7 +146,6 @@ func (RandCollector) GetMetricTypes(cfg plugin.Config) ([]plugin.Metric, error) 
 	for _, val := range vals {
 		metric := plugin.Metric{
 			Namespace: plugin.NewNamespace("random", val),
-			Version:   1,
 		}
 		metrics = append(metrics, metric)
 	}

--- a/examples/snap-plugin-collector-rand/rand/rand.go
+++ b/examples/snap-plugin-collector-rand/rand/rand.go
@@ -153,14 +153,12 @@ func (RandCollector) GetMetricTypes(cfg plugin.Config) ([]plugin.Metric, error) 
 	for _, val := range vals {
 		metric := plugin.Metric{
 			Namespace: plugin.NewNamespace("random", val),
-			Version:   1,
 		}
 		metrics = append(metrics, metric)
 	}
 	if req {
 		metrics = append(metrics, plugin.Metric{
 			Namespace: plugin.NewNamespace("static", "string"),
-			Version:   1,
 		})
 	}
 	return metrics, nil


### PR DESCRIPTION
Hardcoded version there (in GetMetricType) will cause an issue in the case of the future incrementing pluginVersion.

### How to check it:
 - incremented pluginVersion (in main.go) to value "2"
- build exemplary collector plugin and load it
- `snaptel metric list` will show that version of available metrics equals 1 (even they are exposed by plugin in ver 2); 
