### PR TITLE
Add GRPC server options to meta options for plugins

### DIFF
--- a/v1/plugin/meta.go
+++ b/v1/plugin/meta.go
@@ -19,7 +19,10 @@ limitations under the License.
 
 package plugin
 
-import "time"
+import (
+	"time"
+	"google.golang.org/grpc"
+)
 
 type router int
 
@@ -106,6 +109,12 @@ func (t metaRPCType) String() string {
 	}
 }
 
+func GRPCServerOptions(options ...grpc.ServerOption) MetaOpt {
+	return func(m *meta) {
+		m.grpcServerOptions = options
+	}
+}
+
 // meta is the metadata for a plugin
 type meta struct {
 	// A plugin's unique identifier is type:name:version.
@@ -115,15 +124,17 @@ type meta struct {
 	RPCType    metaRPCType
 	RPCVersion int
 
-	ConcurrencyCount int
-	Exclusive        bool
-	Unsecure         bool
-	CacheTTL         time.Duration
-	RoutingStrategy  router
-	CertPath         string
-	KeyPath          string
-	TLSEnabled       bool
-	RootCertPaths    string
+	ConcurrencyCount    int
+	Exclusive           bool
+	Unsecure            bool
+	CacheTTL            time.Duration
+	RoutingStrategy     router
+	CertPath            string
+	KeyPath             string
+	TLSEnabled          bool
+	RootCertPaths       string
+
+	grpcServerOptions   []grpc.ServerOption
 }
 
 // newMeta sets defaults, applies options, and then returns a meta struct

--- a/v1/plugin/plugin.go
+++ b/v1/plugin/plugin.go
@@ -317,7 +317,10 @@ func applySecurityArgsToMeta(m *meta, args *Arg) error {
 // buildGRPCServer configures and builds GRPC server ready to server a plugin
 // instance
 func buildGRPCServer(typeOfPlugin pluginType, name string, version int, arg *Arg, opts ...MetaOpt) (server *grpc.Server, m *meta, err error) {
+	var grpcOptions []grpc.ServerOption
+
 	m = newMeta(typeOfPlugin, name, version, opts...)
+	grpcOptions = append(grpcOptions, m.grpcServerOptions...)
 
 	if err := applySecurityArgsToMeta(m, arg); err != nil {
 		return nil, nil, err
@@ -327,10 +330,9 @@ func buildGRPCServer(typeOfPlugin pluginType, name string, version int, arg *Arg
 		return nil, nil, err
 	}
 	if m.TLSEnabled {
-		server = grpc.NewServer(tlsSetup.updateServerOptions(grpc.Creds(creds))...)
-	} else {
-		server = grpc.NewServer(tlsSetup.updateServerOptions()...)
-	}
+		grpcOptions = append(grpcOptions, grpc.Creds(creds))
+	} 
+	server = grpc.NewServer(tlsSetup.updateServerOptions(grpcOptions...)...)
 	return server, m, nil
 }
 


### PR DESCRIPTION
Implements [intelsdi-x/snap-plugin-lib-go issue #43](https://github.com/intelsdi-x/snap-plugin-lib-go/issues/43) (Allow grpc Server options to be passed by plugin author). 

I took the approach that GRPC server options shouldn't be restricted because restriction can be accomplished later by enforcing (applying) desired restricted options after the user-defined options have been applied.