### PR TITLE
Update config with defaults from config policy

### DIFF
--- a/examples/snap-plugin-collector-rand/rand/rand.go
+++ b/examples/snap-plugin-collector-rand/rand/rand.go
@@ -181,7 +181,6 @@ func (RandCollector) GetConfigPolicy() (plugin.ConfigPolicy, error) {
 			true,
 		)
 	}
-
 	policy.AddNewIntRule([]string{"random", "integer"},
 		"testint",
 		false,
@@ -196,7 +195,8 @@ func (RandCollector) GetConfigPolicy() (plugin.ConfigPolicy, error) {
 
 	policy.AddNewStringRule([]string{"random", "string"},
 		"teststring",
-		false)
+		false,
+		plugin.SetDefaultString("some_string"))
 
 	policy.AddNewBoolRule([]string{"random"},
 		"testbool",

--- a/v1/plugin/config.go
+++ b/v1/plugin/config.go
@@ -23,6 +23,11 @@ package plugin
 // helper functions Get{String,Bool,Float,Int} to be defined.
 type Config map[string]interface{}
 
+// NewConfig returns initialized Config
+func NewConfig() Config {
+	return make(map[string]interface{})
+}
+
 // GetString takes a given key and checks the config for both
 // that the key exists, and that it is of type string.
 // Returns an error if either of these is false.
@@ -103,4 +108,14 @@ func (c Config) GetInt(key string) (int64, error) {
 	}
 
 	return iout, nil
+}
+
+// applyDefaults updates config with defaults from config policy
+func (c Config) applyDefaults(cp ConfigPolicy) {
+	for key, val := range cp.getDefaults() {
+		if _, exist := c[key]; !exist {
+			// set default cfg retrieve from config policy
+			c[key] = val
+		}
+	}
 }

--- a/v1/plugin/config_policy.go
+++ b/v1/plugin/config_policy.go
@@ -149,6 +149,41 @@ func (c *ConfigPolicy) AddNewStringRule(ns []string, key string, req bool, opts 
 	return nil
 }
 
+// getDefaults returns config with defaults from config policy
+func (c *ConfigPolicy) getDefaults() Config {
+	config := NewConfig()
+	for _, v := range c.stringRules {
+		for key, val := range v.Rules {
+			if val.HasDefault {
+				config[key] = val.Default
+			}
+		}
+	}
+	for _, v := range c.boolRules {
+		for key, val := range v.Rules {
+			if val.HasDefault {
+				config[key] = val.Default
+			}
+		}
+	}
+	for _, v := range c.floatRules {
+		for key, val := range v.Rules {
+			if val.HasDefault {
+				config[key] = val.Default
+			}
+		}
+	}
+	for _, v := range c.integerRules {
+		for key, val := range v.Rules {
+			if val.HasDefault {
+				config[key] = val.Default
+			}
+		}
+	}
+
+	return config
+}
+
 func newGetConfigPolicyReply(cfg ConfigPolicy) *rpc.GetConfigPolicyReply {
 	return &rpc.GetConfigPolicyReply{
 		BoolPolicy:    cfg.boolRules,

--- a/v1/plugin/config_policy_test.go
+++ b/v1/plugin/config_policy_test.go
@@ -114,6 +114,20 @@ func TestConfigPolicy(t *testing.T) {
 				}
 			})
 		}
+		Convey("Test Config Policy getting defaults", func() {
+			// get config policy defaults
+			cfg := p.getDefaults()
+			So(cfg, ShouldNotBeEmpty)
+			So(cfg["StringWithDefault"], ShouldEqual, "sss")
+			So(cfg["boolRequired"], ShouldEqual, true)
+			So(cfg["float"], ShouldEqual, 12.1)
+			So(cfg["integer"], ShouldEqual, 12)
+
+			Convey("config rules without default should be skipped", func() {
+				_, exist := cfg["StringWithoutDefault"]
+				So(exist, ShouldBeFalse)
+			})
+		})
 	})
 }
 


### PR DESCRIPTION
### Summary of changes:
 - added `applyDefaults` to update providing config with defaults from config policy
- added `getDefaults` to retrieve defaults from config policy

### Before:
$ ./snap-plugin-collector-rand
There are no passing defaults defined in config policy

```

Config Policy:
NAMESPACE        KEY             TYPE            REQUIRED        DEFAULT         MINIMUM         MAXIMUM
random.string    teststring      string          false           some_string


Metrics that can be collected right now are:
 Namespace: /random/string                  Type: string      Value: Reply hazy try again
```

### After:
Diagnostic might be run without providing config  - defaults value will be used
$ ./snap-plugin-collector-rand


```
Config Policy:
NAMESPACE        KEY             TYPE            REQUIRED        DEFAULT         MINIMUM         MAXIMUM
random.string    teststring      string          false           some_string

Metrics that can be collected right now are:
    Namespace: /random/string            Type: string      Value: some_string

```
