### PR TITLE
Update glide workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,6 @@ gin-bin
 tags
 .vscode/
 vendor/
-glide.lock
 
 # we don't vendor godep _workspace
 **/Godeps/_workspace/**

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,73 @@
+hash: d7e1da0b3a7514c292981ccd4dc28830a1b0fabb47a2b361c120361e83c9eca7
+updated: 2017-07-31T14:15:28.852630132+02:00
+imports:
+- name: github.com/golang/protobuf
+  version: 748d386b5c1ea99658fd69fe9f03991ce86a90c1
+  subpackages:
+  - proto
+  - ptypes/any
+- name: github.com/julienschmidt/httprouter
+  version: 8c199fb6259ffc1af525cc3ad52ee60ba8359669
+- name: github.com/Sirupsen/logrus
+  version: a3f95b5c423586578a4e099b11a46c2479628cac
+- name: github.com/urfave/cli
+  version: 0bdeddeeb0f650497d603c4ad7b20cfe685682f6
+- name: golang.org/x/net
+  version: f5079bd7f6f74e23c4d65efa0f4ce14cbd6a3c0f
+  subpackages:
+  - context
+  - http2
+  - http2/hpack
+  - idna
+  - internal/timeseries
+  - lex/httplex
+  - trace
+- name: golang.org/x/sys
+  version: 0f826bdd13b500be0f1d4004938ad978fcc6031e
+  subpackages:
+  - unix
+- name: golang.org/x/text
+  version: 3bd178b88a8180be2df394a1fbb81313916f0e7b
+  subpackages:
+  - secure/bidirule
+  - transform
+  - unicode/bidi
+  - unicode/norm
+- name: google.golang.org/genproto
+  version: b0a3dcfcd1a9bd48e63634bd8802960804cf8315
+  subpackages:
+  - googleapis/rpc/status
+- name: google.golang.org/grpc
+  version: b8669c35455183da6d5c474ea6e72fbf55183274
+  subpackages:
+  - codes
+  - credentials
+  - grpclb/grpc_lb_v1
+  - grpclog
+  - internal
+  - keepalive
+  - metadata
+  - naming
+  - peer
+  - stats
+  - status
+  - tap
+  - transport
+testImports:
+- name: github.com/gopherjs/gopherjs
+  version: 2b1d432c8a82c9bff0b0baffaeb3ec6e92974112
+  subpackages:
+  - js
+- name: github.com/jtolds/gls
+  version: 77f18212c9c7edc9bd6a33d383a7b545ce62f064
+- name: github.com/smartystreets/assertions
+  version: 4ea54c1f28ad3ae597e76607dea3871fa177e263
+  subpackages:
+  - internal/go-render/render
+  - internal/oglematchers
+- name: github.com/smartystreets/goconvey
+  version: d4c757aa9afd1e2fc1832aaab209b5794eb336e1
+  subpackages:
+  - convey
+  - convey/gotest
+  - convey/reporting

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,44 +1,24 @@
 package: github.com/intelsdi-x/snap-plugin-lib-go
 import:
+- package: github.com/Sirupsen/logrus
+  version: ^1.0.2
 - package: github.com/golang/protobuf
-  version: 888eb0692c857ec880338addf316bd662d5e630e
   subpackages:
   - proto
-- package: github.com/gopherjs/gopherjs
-  version: 4b53e1bddba0e2f734514aeb6c02db652f4c6fe8
-  subpackages:
-  - js
-- package: github.com/jtolds/gls
-  version: 8ddce2a84170772b95dd5d576c48d517b22cac63
-- package: github.com/smartystreets/assertions
-  version: 443d812296a84445c202c085f19e18fc238f8250
-  subpackages:
-  - internal/go-render/render
-  - internal/oglematchers
-- package: github.com/smartystreets/goconvey
-  version: 995f5b2e021c69b8b028ba6d0b05c1dd500783db
-  subpackages:
-  - convey
-  - convey/gotest
-  - convey/reporting
+- package: github.com/julienschmidt/httprouter
+  version: ^1.1.0
+- package: github.com/urfave/cli
+  version: ^1.19.1
 - package: golang.org/x/net
-  version: 054b33e6527139ad5b1ec2f6232c3b175bd9a30c
   subpackages:
   - context
-  - http2/hpack
-  - internal/timeseries
-  - lex/httplex
-  - trace
 - package: google.golang.org/grpc
-  version: ^v1.4
+  version: ^1.4
   subpackages:
-  - codes
   - credentials
-  - grpclog
-  - internal
   - metadata
-  - naming
-  - peer
-  - transport
-- package: github.com/Sirupsen/logrus
-  version: ^0.11.5
+testImport:
+- package: github.com/smartystreets/goconvey
+  version: ^1.6.2
+  subpackages:
+  - convey


### PR DESCRIPTION
This PR adds glide.lock, and changes glide.yaml to version ranges.

Locking dependencies to specific version in `glide.yaml` isn't intended workflow of Glide. `glide.lock` placed in `.gitignore` can cause different behaviours in different environments as glide prioritizes versions supplied in `glide.lock`. Locks should be moved to `glide.lock` and `glide.yaml` should take advantage of Semantic Versioning.

This also allows updating dependencies with simple `glide up`.