### PR TITLE
update logrus import path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,24 @@
-## Snap Plugin Library for Go  [![Build Status](https://travis-ci.org/intelsdi-x/snap-plugin-lib-go.svg?branch=master)](https://travis-ci.org/intelsdi-x/snap-plugin-lib-go) [![Go Report Card](https://goreportcard.com/badge/intelsdi-x/snap-plugin-lib-go)](https://goreportcard.com/report/intelsdi-x/snap-plugin-lib-go)
+# Snap Plugin Library for Go  [![Build Status](https://travis-ci.org/intelsdi-x/snap-plugin-lib-go.svg?branch=master)](https://travis-ci.org/intelsdi-x/snap-plugin-lib-go) [![Go Report Card](https://goreportcard.com/badge/intelsdi-x/snap-plugin-lib-go)](https://goreportcard.com/report/intelsdi-x/snap-plugin-lib-go)
 
-This is a library for writing plugins in Go for the [Snap telemetry framework](https://github.com/intelsdi-x/snap). 
+This is a library for writing plugins in Go for the [Snap telemetry framework](https://github.com/intelsdi-x/snap).
 
 ----
 
+**Notice:**
+Due to standarization which has been made in [Logrus project](https://github.com/sirupsen/logrus), its import path has been changed from `Sirupsen` to `sirupsen`.
+If you see [case-sensitive import collision reporting by glide](https://user-images.githubusercontent.com/11335874/31628492-232b9e0c-b2b1-11e7-8d3c-3d38914233bc.png) after updating your plugin to the latest snap-plugin-lib-go,
+please do the following steps:
+ - change every import of Logrus to the lower case: `github./com/sirupsen/logrus`,
+ - delete folder `vendor/github.com/Sirupsen`,
+ - rename references in glide.yaml and glide.lock
+ - clear glide cache (`glide -c`),
+ - update dependencies (`glide update`)
+
+More information you can find in [Logrus GitHub repo](https://github.com/sirupsen/logrus/issues/570#issuecomment-313933276).
+
+----
+
+## Table of Contents
 1. [Writing a Plugin](#writing-a-plugin)
     * [Before Writing a Snap Plugin](#before-writing-a-snap-plugin)
 2.  [Brief Overview of Snap Architecture](#brief-overview-of-snap-architecture)

--- a/glide.lock
+++ b/glide.lock
@@ -46,7 +46,7 @@ imports:
   subpackages:
   - googleapis/rpc/status
 - name: google.golang.org/grpc
-  version: f92cdcd7dcdc69e81b2d7b338479a19a8723cfa3
+  version: b8669c35455183da6d5c474ea6e72fbf55183274
   subpackages:
   - codes
   - connectivity

--- a/glide.lock
+++ b/glide.lock
@@ -1,17 +1,24 @@
-hash: d7e1da0b3a7514c292981ccd4dc28830a1b0fabb47a2b361c120361e83c9eca7
-updated: 2017-07-31T14:15:28.852630132+02:00
+hash: 487c97fb40a9826478ed3cd382f933d391da3f8463ffb71e4c0ccfcc545a69ff
+updated: 2017-09-30T13:34:51.196736604-04:00
 imports:
 - name: github.com/golang/protobuf
   version: 748d386b5c1ea99658fd69fe9f03991ce86a90c1
   subpackages:
   - proto
+  - ptypes
   - ptypes/any
+  - ptypes/duration
+  - ptypes/timestamp
 - name: github.com/julienschmidt/httprouter
   version: 8c199fb6259ffc1af525cc3ad52ee60ba8359669
-- name: github.com/Sirupsen/logrus
-  version: a3f95b5c423586578a4e099b11a46c2479628cac
+- name: github.com/sirupsen/logrus
+  version: f006c2ac4710855cf0f916dd6b77acf6b048dc6e
 - name: github.com/urfave/cli
-  version: 0bdeddeeb0f650497d603c4ad7b20cfe685682f6
+  version: cfb38830724cc34fedffe9a2a29fb54fa9169cd1
+- name: golang.org/x/crypto
+  version: eb71ad9bd329b5ac0fd0148dd99bd62e8be8e035
+  subpackages:
+  - ssh/terminal
 - name: golang.org/x/net
   version: f5079bd7f6f74e23c4d65efa0f4ce14cbd6a3c0f
   subpackages:
@@ -26,6 +33,7 @@ imports:
   version: 0f826bdd13b500be0f1d4004938ad978fcc6031e
   subpackages:
   - unix
+  - windows
 - name: golang.org/x/text
   version: 3bd178b88a8180be2df394a1fbb81313916f0e7b
   subpackages:
@@ -38,11 +46,12 @@ imports:
   subpackages:
   - googleapis/rpc/status
 - name: google.golang.org/grpc
-  version: b8669c35455183da6d5c474ea6e72fbf55183274
+  version: f92cdcd7dcdc69e81b2d7b338479a19a8723cfa3
   subpackages:
   - codes
+  - connectivity
   - credentials
-  - grpclb/grpc_lb_v1
+  - grpclb/grpc_lb_v1/messages
   - grpclog
   - internal
   - keepalive
@@ -66,7 +75,7 @@ testImports:
   - internal/go-render/render
   - internal/oglematchers
 - name: github.com/smartystreets/goconvey
-  version: d4c757aa9afd1e2fc1832aaab209b5794eb336e1
+  version: 9e8dc3f972df6c8fcc0375ef492c24d0bb204857
   subpackages:
   - convey
   - convey/gotest

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,6 +1,6 @@
 package: github.com/intelsdi-x/snap-plugin-lib-go
 import:
-- package: github.com/Sirupsen/logrus
+- package: github.com/sirupsen/logrus
   version: ^1.0.2
 - package: github.com/golang/protobuf
   subpackages:

--- a/v1/plugin/plugin.go
+++ b/v1/plugin/plugin.go
@@ -41,8 +41,8 @@ import (
 
 	"text/tabwriter"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/snap-plugin-lib-go/v1/plugin/rpc"
+	log "github.com/sirupsen/logrus"
 )
 
 var (

--- a/v1/plugin/plugin_test.go
+++ b/v1/plugin/plugin_test.go
@@ -33,7 +33,7 @@ import (
 
 	"os"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	. "github.com/smartystreets/goconvey/convey"
 	"google.golang.org/grpc"
 )

--- a/v1/plugin/session.go
+++ b/v1/plugin/session.go
@@ -9,8 +9,8 @@ import (
 
 	"net/http/pprof"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/julienschmidt/httprouter"
+	log "github.com/sirupsen/logrus"
 )
 
 // Arg represents arguments passed to startup of Plugin

--- a/v1/plugin/stream_collector_proxy.go
+++ b/v1/plugin/stream_collector_proxy.go
@@ -9,8 +9,8 @@ import (
 
 	"golang.org/x/net/context"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/snap-plugin-lib-go/v1/plugin/rpc"
+	log "github.com/sirupsen/logrus"
 )
 
 const (


### PR DESCRIPTION
https://github.com/sirupsen/logrus/issues/570#issuecomment-313933276

Due to the recent change of Sirupsen->sirupsen this import path must be updated in the client-lib.
I will make a similar PR to the main snap project.