### PR TITLE
Addressed go report issues: fix misspell and format with `gofmt -s`

### DIFF
--- a/examples/snap-plugin-collector-rand/rand/rand_test.go
+++ b/examples/snap-plugin-collector-rand/rand/rand_test.go
@@ -36,7 +36,7 @@ func TestRandCollector(t *testing.T) {
 	Convey("Test RandCollector", t, func() {
 		Convey("Collect Integer", func() {
 			metrics := []plugin.Metric{
-				plugin.Metric{
+				{
 					Namespace: plugin.NewNamespace("random", "integer"),
 					Config:    map[string]interface{}{"testint": int64(34)},
 					Data:      34,
@@ -52,7 +52,7 @@ func TestRandCollector(t *testing.T) {
 		})
 		Convey("Collect Float", func() {
 			metrics := []plugin.Metric{
-				plugin.Metric{
+				{
 					Namespace: plugin.NewNamespace("random", "float"),
 					Config:    map[string]interface{}{"testfloat": 3.345},
 					Data:      3.345,
@@ -68,7 +68,7 @@ func TestRandCollector(t *testing.T) {
 		})
 		Convey("Collect String", func() {
 			metrics := []plugin.Metric{
-				plugin.Metric{
+				{
 					Namespace: plugin.NewNamespace("random", "string"),
 					Config:    map[string]interface{}{"teststring": "charm"},
 					Data:      "charm",

--- a/examples/snap-plugin-processor-reverse/reverse/reverse_test.go
+++ b/examples/snap-plugin-processor-reverse/reverse/reverse_test.go
@@ -36,7 +36,7 @@ func TestReverseProcessor(t *testing.T) {
 	Convey("Test Processor", t, func() {
 		Convey("Process int metric", func() {
 			metrics := []plugin.Metric{
-				plugin.Metric{
+				{
 					Namespace: plugin.NewNamespace("x", "y", "z"),
 					Config:    map[string]interface{}{"pw": "123aB"},
 					Data:      345678,
@@ -52,7 +52,7 @@ func TestReverseProcessor(t *testing.T) {
 		})
 		Convey("Process int32 metric", func() {
 			metrics := []plugin.Metric{
-				plugin.Metric{
+				{
 					Namespace: plugin.NewNamespace("x", "y", "z"),
 					Config:    map[string]interface{}{"pw": "123aB"},
 					Data:      int32(345678),
@@ -68,7 +68,7 @@ func TestReverseProcessor(t *testing.T) {
 		})
 		Convey("Process int64 metric", func() {
 			metrics := []plugin.Metric{
-				plugin.Metric{
+				{
 					Namespace: plugin.NewNamespace("x", "y", "z"),
 					Config:    map[string]interface{}{"pw": "123aB"},
 					Data:      int64(345678999999),
@@ -84,7 +84,7 @@ func TestReverseProcessor(t *testing.T) {
 		})
 		Convey("Process float metric", func() {
 			metrics := []plugin.Metric{
-				plugin.Metric{
+				{
 					Namespace: plugin.NewNamespace("x", "y", "z"),
 					Config:    map[string]interface{}{"pw": 123},
 					Data:      42.42,
@@ -100,7 +100,7 @@ func TestReverseProcessor(t *testing.T) {
 		})
 		Convey("Process float32 metric", func() {
 			metrics := []plugin.Metric{
-				plugin.Metric{
+				{
 					Namespace: plugin.NewNamespace("x", "y", "z"),
 					Config:    map[string]interface{}{"pw": 123},
 					Data:      float32(24.24),
@@ -117,7 +117,7 @@ func TestReverseProcessor(t *testing.T) {
 		Convey("Process string metric", func() {
 			curTime := time.Now()
 			metrics := []plugin.Metric{
-				plugin.Metric{
+				{
 					Namespace:   plugin.NewNamespace("x", "y", "z"),
 					Config:      map[string]interface{}{"pw": 123.78},
 					Data:        "luck charm",

--- a/examples/snap-plugin-publisher-file/file/file_test.go
+++ b/examples/snap-plugin-publisher-file/file/file_test.go
@@ -36,7 +36,7 @@ func TestFilePublisher(t *testing.T) {
 	Convey("Test publish", t, func() {
 		Convey("Publish without a config file", func() {
 			metrics := []plugin.Metric{
-				plugin.Metric{
+				{
 					Namespace: plugin.NewNamespace("x", "y", "z"),
 					Config:    map[string]interface{}{"pw": "123aB"},
 					Data:      3,
@@ -50,7 +50,7 @@ func TestFilePublisher(t *testing.T) {
 		})
 		Convey("Publish with a config file", func() {
 			metrics := []plugin.Metric{
-				plugin.Metric{
+				{
 					Namespace: plugin.NewNamespace("x", "y", "z"),
 					Config:    map[string]interface{}{"pw": "abc123"},
 					Data:      3,

--- a/v1/plugin/collector_proxy_test.go
+++ b/v1/plugin/collector_proxy_test.go
@@ -115,7 +115,7 @@ func getTestMetricData() map[string]*rpc.Metric {
 		val := fmt.Sprintf("val%d", i)
 		desc := fmt.Sprintf("desc%d", i)
 		ns := []*rpc.NamespaceElement{
-			&rpc.NamespaceElement{Name: name, Value: val, Description: desc},
+			{Name: name, Value: val, Description: desc},
 		}
 		m := &rpc.Metric{
 			Namespace:          ns,
@@ -136,7 +136,7 @@ func getTestMetricData() map[string]*rpc.Metric {
 		val := fmt.Sprintf("val%d", i)
 		desc := fmt.Sprintf("desc%d", i)
 		ns := []*rpc.NamespaceElement{
-			&rpc.NamespaceElement{Name: name, Value: val, Description: desc},
+			{Name: name, Value: val, Description: desc},
 		}
 		m := &rpc.Metric{
 			Namespace:          ns,
@@ -157,7 +157,7 @@ func getTestMetricData() map[string]*rpc.Metric {
 		val := fmt.Sprintf("val%d", i)
 		desc := fmt.Sprintf("desc%d", i)
 		ns := []*rpc.NamespaceElement{
-			&rpc.NamespaceElement{Name: name, Value: val, Description: desc},
+			{Name: name, Value: val, Description: desc},
 		}
 
 		m := &rpc.Metric{
@@ -179,7 +179,7 @@ func getTestMetricData() map[string]*rpc.Metric {
 		val := fmt.Sprintf("val%d", i)
 		desc := fmt.Sprintf("desc%d", i)
 		ns := []*rpc.NamespaceElement{
-			&rpc.NamespaceElement{Name: name, Value: val, Description: desc},
+			{Name: name, Value: val, Description: desc},
 		}
 		m := &rpc.Metric{
 			Namespace:          ns,
@@ -200,7 +200,7 @@ func getTestMetricData() map[string]*rpc.Metric {
 		val := fmt.Sprintf("val%d", i)
 		desc := fmt.Sprintf("desc%d", i)
 		ns := []*rpc.NamespaceElement{
-			&rpc.NamespaceElement{Name: name, Value: val, Description: desc},
+			{Name: name, Value: val, Description: desc},
 		}
 		m := &rpc.Metric{
 			Namespace:          ns,
@@ -221,7 +221,7 @@ func getTestMetricData() map[string]*rpc.Metric {
 		val := fmt.Sprintf("val%d", i)
 		desc := fmt.Sprintf("desc%d", i)
 		ns := []*rpc.NamespaceElement{
-			&rpc.NamespaceElement{Name: name, Value: val, Description: desc},
+			{Name: name, Value: val, Description: desc},
 		}
 		m := &rpc.Metric{
 			Namespace:          ns,

--- a/v1/plugin/config_policy_test.go
+++ b/v1/plugin/config_policy_test.go
@@ -154,7 +154,7 @@ type testCaseConfigPolicy struct {
 func configPolicyTestCases() []testCaseConfigPolicy {
 	tc := []testCaseConfigPolicy{
 		// test stringRule with Default value
-		testCaseConfigPolicy{
+		{
 			input: inputConfigPolicy{
 				ns:   []string{"a", "b", "c"},
 				key:  "StringWithDefault",
@@ -170,7 +170,7 @@ func configPolicyTestCases() []testCaseConfigPolicy {
 			},
 		},
 		// test stringRule without Default value
-		testCaseConfigPolicy{
+		{
 			input: inputConfigPolicy{
 				key: "StringWithoutDefault",
 				req: true,
@@ -182,7 +182,7 @@ func configPolicyTestCases() []testCaseConfigPolicy {
 			},
 		},
 		// test boolRule required
-		testCaseConfigPolicy{
+		{
 			input: inputConfigPolicy{
 				ns:   []string{"a1", "b1", "c1"},
 				key:  "boolRequired",
@@ -198,7 +198,7 @@ func configPolicyTestCases() []testCaseConfigPolicy {
 			},
 		},
 		// test boolRule not required
-		testCaseConfigPolicy{
+		{
 			input: inputConfigPolicy{
 				key:  "boolNotRequired",
 				req:  false,
@@ -212,7 +212,7 @@ func configPolicyTestCases() []testCaseConfigPolicy {
 			},
 		},
 		// test floatRule
-		testCaseConfigPolicy{
+		{
 			input: inputConfigPolicy{
 				ns:   []string{"a2", "b2", "c2"},
 				key:  "float",
@@ -228,7 +228,7 @@ func configPolicyTestCases() []testCaseConfigPolicy {
 			},
 		},
 		// test integerRule
-		testCaseConfigPolicy{
+		{
 			input: inputConfigPolicy{
 				ns:   []string{"a3", "b3", "c3"},
 				key:  "integer",

--- a/v1/plugin/config_test.go
+++ b/v1/plugin/config_test.go
@@ -162,19 +162,19 @@ type testCaseConfig struct {
 
 func configPassTestCases() []testCaseConfig {
 	tc := []testCaseConfig{
-		testCaseConfig{
+		{
 			expected: "rain",
 			input:    "a",
 		},
-		testCaseConfig{
+		{
 			expected: int64(123),
 			input:    "b",
 		},
-		testCaseConfig{
+		{
 			expected: 32.5,
 			input:    "c",
 		},
-		testCaseConfig{
+		{
 			expected: true,
 			input:    "d",
 		},
@@ -184,35 +184,35 @@ func configPassTestCases() []testCaseConfig {
 
 func configErrTestCases() []testCaseConfig {
 	tc := []testCaseConfig{
-		testCaseConfig{
+		{
 			expected: true,
 			input:    "f",
 		},
-		testCaseConfig{
+		{
 			expected: true,
 			input:    "h",
 		},
-		testCaseConfig{
+		{
 			expected: 12.4,
 			input:    "x",
 		},
-		testCaseConfig{
+		{
 			expected: 12.1,
 			input:    "i",
 		},
-		testCaseConfig{
+		{
 			expected: "bbb",
 			input:    "y",
 		},
-		testCaseConfig{
+		{
 			expected: "bbb",
 			input:    "j",
 		},
-		testCaseConfig{
+		{
 			expected: int64(12),
 			input:    "z",
 		},
-		testCaseConfig{
+		{
 			expected: int64(13),
 			input:    "k",
 		},

--- a/v1/plugin/grpc_test.go
+++ b/v1/plugin/grpc_test.go
@@ -75,18 +75,18 @@ var (
 	}
 
 	grpcTestPublishConfigMapInput = map[string]Config{
-		"proper/string":  Config{"string": "ok"},
-		"proper/bool":    Config{"bool": true},
-		"proper/float":   Config{"float": float64(-1.2345)},
-		"proper/int":     Config{"int": int64(-234567)},
-		"missing/string": Config{},
-		"missing/bool":   Config{},
-		"missing/float":  Config{},
-		"missing/int":    Config{},
-		"invalid/string": Config{"string": false},
-		"invalid/bool":   Config{"bool": ""},
-		"invalid/float":  Config{"float": ""},
-		"invalid/int":    Config{"int": ""},
+		"proper/string":  {"string": "ok"},
+		"proper/bool":    {"bool": true},
+		"proper/float":   {"float": float64(-1.2345)},
+		"proper/int":     {"int": int64(-234567)},
+		"missing/string": {},
+		"missing/bool":   {},
+		"missing/float":  {},
+		"missing/int":    {},
+		"invalid/string": {"string": false},
+		"invalid/bool":   {"bool": ""},
+		"invalid/float":  {"float": ""},
+		"invalid/int":    {"int": ""},
 	}
 
 	grpcTestPublishConfigMapOutput = map[string]string{
@@ -408,7 +408,7 @@ func TestCollectorFlow(t *testing.T) {
 		})
 		Convey("metrics from GetMetricTypes should be forwarded to caller", func() {
 			mockCollector.doGetMetricTypes = func(_ Config) (dst []Metric, err error) {
-				for k, _ := range grpcTestMetricTypesMap {
+				for k := range grpcTestMetricTypesMap {
 					ns := NewNamespace(strings.Split(k, "/")...)
 					dst = append(dst, Metric{Namespace: ns, Data: int64(0)})
 				}

--- a/v1/plugin/meta_test.go
+++ b/v1/plugin/meta_test.go
@@ -48,15 +48,15 @@ type metaTestCase struct {
 
 func metaTestCases() []metaTestCase {
 	tc := []metaTestCase{
-		metaTestCase{
+		{
 			input:  *newMeta(collectorType, "fakeCollector", 0, ConcurrencyCount(0), Exclusive(false), RoutingStrategy(LRURouter), CacheTTL(time.Millisecond*0)),
 			output: meta{Type: collectorType, Name: "fakeCollector", Version: 0, ConcurrencyCount: 0, Exclusive: false, RoutingStrategy: 0, RPCType: gRPC, RPCVersion: 1, Unsecure: true, CacheTTL: time.Millisecond * 0},
 		},
-		metaTestCase{
+		{
 			input:  *newMeta(processorType, "fakeProcessor", 1, ConcurrencyCount(1), Exclusive(true), RoutingStrategy(StickyRouter), CacheTTL(time.Millisecond*1)),
 			output: meta{Type: processorType, Name: "fakeProcessor", Version: 1, ConcurrencyCount: 1, Exclusive: true, RoutingStrategy: 1, RPCType: gRPC, RPCVersion: 1, Unsecure: true, CacheTTL: time.Millisecond * 1},
 		},
-		metaTestCase{
+		{
 			input:  *newMeta(publisherType, "fakePublisher", 10, ConcurrencyCount(8), Exclusive(false), RoutingStrategy(ConfigBasedRouter), CacheTTL(time.Millisecond*1)),
 			output: meta{Type: publisherType, Name: "fakePublisher", Version: 10, ConcurrencyCount: 8, Exclusive: false, RoutingStrategy: 2, RPCType: gRPC, RPCVersion: 1, Unsecure: true, CacheTTL: time.Millisecond * 1},
 		},

--- a/v1/plugin/metric_test.go
+++ b/v1/plugin/metric_test.go
@@ -193,7 +193,7 @@ type testCaseMetric struct {
 
 func metricTestCases() []testCaseMetric {
 	tc := []testCaseMetric{
-		testCaseMetric{
+		{
 			input: Metric{
 				Namespace: NewNamespace("a", "b", "c"),
 				Version:   0,
@@ -203,14 +203,14 @@ func metricTestCases() []testCaseMetric {
 				},
 			},
 		},
-		testCaseMetric{
+		{
 			input: Metric{
 				Namespace: NewNamespace("a1", "b1", "c1").AddStaticElement("d").AddDynamicElement("charm", "desc").AddStaticElements("x", "y"),
 				Data:      "abc",
 				Unit:      "string",
 			},
 		},
-		testCaseMetric{
+		{
 			input: Metric{
 				Namespace: NewNamespace("a2", "b2", "c2"),
 				Version:   1,
@@ -219,7 +219,7 @@ func metricTestCases() []testCaseMetric {
 				Tags:      map[string]string{"label": "abc"},
 			},
 		},
-		testCaseMetric{
+		{
 			input: Metric{
 				Namespace:          NewNamespace("a3", "b3", "c3"),
 				Version:            2,
@@ -230,7 +230,7 @@ func metricTestCases() []testCaseMetric {
 				lastAdvertisedTime: time.Now(),
 			},
 		},
-		testCaseMetric{
+		{
 			input: Metric{
 				Namespace:          NewNamespace("a4", "b4", "c4"),
 				Version:            3,
@@ -241,7 +241,7 @@ func metricTestCases() []testCaseMetric {
 				lastAdvertisedTime: time.Now(),
 			},
 		},
-		testCaseMetric{
+		{
 			input: Metric{
 				Namespace:          NewNamespace("a5", "b5", "c5"),
 				Version:            4,
@@ -253,7 +253,7 @@ func metricTestCases() []testCaseMetric {
 				lastAdvertisedTime: time.Now(),
 			},
 		},
-		testCaseMetric{
+		{
 			input: Metric{
 				Namespace:          NewNamespace("a6", "b6", "c7"),
 				Version:            5,
@@ -264,7 +264,7 @@ func metricTestCases() []testCaseMetric {
 				lastAdvertisedTime: time.Now(),
 			},
 		},
-		testCaseMetric{
+		{
 			input: Metric{
 				Namespace:          NewNamespace("a8", "b8", "c8"),
 				Version:            6,
@@ -275,7 +275,7 @@ func metricTestCases() []testCaseMetric {
 				lastAdvertisedTime: time.Now(),
 			},
 		},
-		testCaseMetric{
+		{
 			input: Metric{
 				Namespace:          NewNamespace("a9", "b9", "29"),
 				Version:            7,
@@ -286,7 +286,7 @@ func metricTestCases() []testCaseMetric {
 				lastAdvertisedTime: time.Now(),
 			},
 		},
-		testCaseMetric{
+		{
 			input: Metric{
 				Namespace:          NewNamespace("a10", "b10", "c10"),
 				Version:            9,
@@ -297,7 +297,7 @@ func metricTestCases() []testCaseMetric {
 				lastAdvertisedTime: time.Now(),
 			},
 		},
-		testCaseMetric{
+		{
 			input: Metric{
 				Namespace:          NewNamespace("a11", "b11", "c11"),
 				Version:            10,
@@ -308,7 +308,7 @@ func metricTestCases() []testCaseMetric {
 				lastAdvertisedTime: time.Now(),
 			},
 		},
-		testCaseMetric{
+		{
 			input: Metric{
 				Namespace:          NewNamespace("a12", "b12", "c12"),
 				Version:            11,
@@ -319,7 +319,7 @@ func metricTestCases() []testCaseMetric {
 				lastAdvertisedTime: time.Now(),
 			},
 		},
-		testCaseMetric{
+		{
 			input: Metric{
 				Namespace:          NewNamespace(NewNamespaceElement("").Value),
 				Version:            10,
@@ -336,7 +336,7 @@ func metricTestCases() []testCaseMetric {
 
 func metricNoDefaultTimeTestCases() []testCaseMetric {
 	tc := []testCaseMetric{
-		testCaseMetric{
+		{
 			input: Metric{
 				Namespace: NewNamespace("a", "b", "c"),
 				Version:   0,
@@ -346,14 +346,14 @@ func metricNoDefaultTimeTestCases() []testCaseMetric {
 				},
 			},
 		},
-		testCaseMetric{
+		{
 			input: Metric{
 				Namespace: NewNamespace("a1", "b1", "c1").AddStaticElement("d").AddDynamicElement("charm", "desc").AddStaticElements("x", "y"),
 				Data:      "abc",
 				Unit:      "string",
 			},
 		},
-		testCaseMetric{
+		{
 			input: Metric{
 				Namespace: NewNamespace("a2", "b2", "c2"),
 				Version:   1,
@@ -367,7 +367,7 @@ func metricNoDefaultTimeTestCases() []testCaseMetric {
 
 func metricHasDefaultTimeTestCases() []testCaseMetric {
 	tc := []testCaseMetric{
-		testCaseMetric{
+		{
 			input: Metric{
 				Namespace: NewNamespace("a", "b", "c"),
 				Version:   0,
@@ -379,7 +379,7 @@ func metricHasDefaultTimeTestCases() []testCaseMetric {
 				lastAdvertisedTime: time.Now(),
 			},
 		},
-		testCaseMetric{
+		{
 			input: Metric{
 				Namespace:          NewNamespace("x", "y", "z").AddStaticElement("d").AddDynamicElement("charm", "desc").AddStaticElements("r", "s"),
 				Data:               "abc",
@@ -399,7 +399,7 @@ type testCaseMetricConfig struct {
 
 func metricConfigTestCases() []testCaseMetricConfig {
 	tc := []testCaseMetricConfig{
-		testCaseMetricConfig{
+		{
 			input: rpc.ConfigMap{
 				IntMap:    map[string]int64{"abc": 123},
 				StringMap: map[string]string{"xyz": "abc"},
@@ -419,12 +419,12 @@ func metricConfigTestCases() []testCaseMetricConfig {
 
 func metricNamespaceTestCases() []Namespace {
 	nss := []Namespace{
-		Namespace{
+		{
 			NamespaceElement{Value: "a"},
 			NamespaceElement{Value: "b"},
 			NamespaceElement{Value: "c"},
 		},
-		Namespace{
+		{
 			NamespaceElement{Value: "a"},
 			NamespaceElement{Name: "rst", Value: "*", Description: "range"},
 			NamespaceElement{Value: "c"},

--- a/v1/plugin/plugin.go
+++ b/v1/plugin/plugin.go
@@ -198,7 +198,7 @@ type tlsServerDefaultSetup struct {
 // tlsSetup holds TLS setup utility for plugin lib
 var tlsSetup tlsServerSetup = tlsServerDefaultSetup{}
 
-// makeTLSConfig provides TLS configuraton template for plugins, setting
+// makeTLSConfig provides TLS configuration template for plugins, setting
 // required verification of client cert and preferred server suites.
 func (ts tlsServerDefaultSetup) makeTLSConfig() *tls.Config {
 	config := tls.Config{

--- a/v1/plugin/rules_test.go
+++ b/v1/plugin/rules_test.go
@@ -75,24 +75,24 @@ type testCaseBool struct {
 
 func createPassTestCases() []testCaseBool {
 	tc := []testCaseBool{
-		testCaseBool{
+		{
 			input: boolInput{
 				key:  "abc",
 				req:  true,
 				opts: SetDefaultBool(true),
 			},
 		},
-		testCaseBool{
+		{
 			input: boolInput{
 				key:  "abc1",
 				req:  false,
 				opts: SetDefaultBool(false),
 			},
 		},
-		testCaseBool{
+		{
 			input: boolInput{ns: []string{"plop"}, key: "xyz", req: true},
 		},
-		testCaseBool{
+		{
 			input: boolInput{ns: []string{"plop"}, key: "abc2", req: false},
 		},
 	}
@@ -101,13 +101,13 @@ func createPassTestCases() []testCaseBool {
 
 func createErrTestCases() []testCaseBool {
 	tc := []testCaseBool{
-		testCaseBool{
+		{
 			input: boolInput{req: true},
 		},
-		testCaseBool{
+		{
 			input: boolInput{key: "", req: false},
 		},
-		testCaseBool{
+		{
 			input: boolInput{
 				key: "", req: false,
 				opts: SetDefaultBool(false),
@@ -166,10 +166,10 @@ type testCaseFloat struct {
 
 func floatErrTestCases() []testCaseFloat {
 	tc := []testCaseFloat{
-		testCaseFloat{
+		{
 			input: floatInput{req: true},
 		},
-		testCaseFloat{
+		{
 			input: floatInput{key: "", req: false},
 		},
 	}
@@ -178,25 +178,25 @@ func floatErrTestCases() []testCaseFloat {
 
 func floatPassTestCases() []testCaseFloat {
 	tc := []testCaseFloat{
-		testCaseFloat{
+		{
 			input: floatInput{key: "xyz", req: true},
 		},
-		testCaseFloat{
+		{
 			input: floatInput{key: "abc", req: false},
 		},
-		testCaseFloat{
+		{
 			input: floatInput{
 				key:  "xyz1",
 				req:  true,
 				opts: []floatRuleOpt{SetDefaultFloat(30.1)}},
 		},
-		testCaseFloat{
+		{
 			input: floatInput{
 				key:  "xyz2",
 				req:  true,
 				opts: []floatRuleOpt{SetMaxFloat(32.1)}},
 		},
-		testCaseFloat{
+		{
 			input: floatInput{
 				key:  "xyz3",
 				req:  false,
@@ -251,27 +251,27 @@ type testCaseInteger struct {
 
 func integerPassTestCases() []testCaseInteger {
 	tc := []testCaseInteger{
-		testCaseInteger{
+		{
 			input: integerInput{key: "xyz", req: true},
 		},
-		testCaseInteger{
+		{
 			input: integerInput{key: "abc", req: false},
 		},
-		testCaseInteger{
+		{
 			input: integerInput{
 				ns:   []string{"plop"},
 				key:  "xyz1",
 				req:  true,
 				opts: []integerRuleOpt{SetDefaultInt(30)}},
 		},
-		testCaseInteger{
+		{
 			input: integerInput{
 				ns:   []string{"plop"},
 				key:  "xyz2",
 				req:  true,
 				opts: []integerRuleOpt{SetMaxInt(64)}},
 		},
-		testCaseInteger{
+		{
 			input: integerInput{
 				ns:   []string{"plop", "world"},
 				key:  "xyz3",
@@ -284,13 +284,13 @@ func integerPassTestCases() []testCaseInteger {
 
 func integerErrTestCases() []testCaseInteger {
 	tc := []testCaseInteger{
-		testCaseInteger{
+		{
 			input: integerInput{req: true},
 		},
-		testCaseInteger{
+		{
 			input: integerInput{key: "", req: false},
 		},
-		testCaseInteger{
+		{
 			input: integerInput{
 				ns:   []string{"plop"},
 				key:  "",
@@ -348,19 +348,19 @@ type testCaseString struct {
 
 func stringPassTestCases() []testCaseString {
 	tc := []testCaseString{
-		testCaseString{
+		{
 			input: stringInput{key: "xyz", req: true},
 		},
-		testCaseString{
+		{
 			input: stringInput{key: "abc", req: false},
 		},
-		testCaseString{
+		{
 			input: stringInput{
 				key:  "deer",
 				req:  true,
 				opts: SetDefaultString("123")},
 		},
-		testCaseString{
+		{
 			input: stringInput{
 				key:  "racoon",
 				req:  false,
@@ -372,13 +372,13 @@ func stringPassTestCases() []testCaseString {
 
 func stringErrTestCases() []testCaseString {
 	tc := []testCaseString{
-		testCaseString{
+		{
 			input: stringInput{req: true},
 		},
-		testCaseString{
+		{
 			input: stringInput{key: "", req: false},
 		},
-		testCaseString{
+		{
 			input: stringInput{
 				key:  "",
 				req:  true,

--- a/v1/plugin/stream_collector_proxy_test.go
+++ b/v1/plugin/stream_collector_proxy_test.go
@@ -110,9 +110,7 @@ func TestStreamMetrics(t *testing.T) {
 			Convey("get metrics through stream proxy", func() {
 				So(pl.outMetric, ShouldNotBeNil)
 				// Create mocked metrics
-				metrics := []Metric{
-					Metric{},
-				}
+				metrics := []Metric{}
 				// Send metrics down to channel every 100 ms
 				pl.doAction(time.Millisecond*100, metrics)
 				select {


### PR DESCRIPTION
### Summary of changes:
- addressed go-report issues (fmt and misspell)

Before | After
-------|--------
![image](https://user-images.githubusercontent.com/11335874/31713127-8ad32d2a-b3fd-11e7-8913-454938ff1ad3.png) | ![image](https://user-images.githubusercontent.com/11335874/31713273-0d0ed0be-b3fe-11e7-9a01-665c54d91c41.png)





