### PR TITLE
Fix issue #80 and update example plugin for server option setting 

### DIFF
--- a/examples/snap-plugin-collector-rand/main.go
+++ b/examples/snap-plugin-collector-rand/main.go
@@ -22,6 +22,7 @@ package main
 import (
 	"github.com/intelsdi-x/snap-plugin-lib-go/examples/snap-plugin-collector-rand/rand"
 	"github.com/intelsdi-x/snap-plugin-lib-go/v1/plugin"
+	"google.golang.org/grpc"
 )
 
 const (
@@ -30,5 +31,5 @@ const (
 )
 
 func main() {
-	plugin.StartCollector(rand.RandCollector{}, pluginName, pluginVersion)
+	plugin.StartCollector(rand.RandCollector{}, pluginName, pluginVersion, plugin.GRPCServerOptions(grpc.MaxMsgSize(2 * 1024)))
 }

--- a/v1/plugin/metric.go
+++ b/v1/plugin/metric.go
@@ -155,13 +155,13 @@ func toProtoConfig(config Config) *rpc.ConfigMap {
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32,
 			reflect.Int64, reflect.Uint, reflect.Uint8, reflect.Uint16,
 			reflect.Uint32, reflect.Uint64:
-			rpcConfig.IntMap[k] = v.(int64)
+			rpcConfig.IntMap[k] = reflect.ValueOf(v).Int()
 		case reflect.Float32, reflect.Float64:
-			rpcConfig.FloatMap[k] = v.(float64)
+			rpcConfig.FloatMap[k] = reflect.ValueOf(v).Float()
 		case reflect.String:
-			rpcConfig.StringMap[k] = v.(string)
+			rpcConfig.StringMap[k] = reflect.ValueOf(v).String()
 		case reflect.Bool:
-			rpcConfig.BoolMap[k] = v.(bool)
+			rpcConfig.BoolMap[k] = reflect.ValueOf(v).Bool()
 		}
 	}
 	return rpcConfig


### PR DESCRIPTION
Description:
Plugins using GRPC aren't passing metric config even if it's specified.
In toProtoMetric function metric's config isn't passed along.
This behaviour differs from plugins using deprecated plugin lib, in which there is a possibility to pass metric's config.

Fix:
Add metric config convert to rpc. ConfigMap.