### PR TITLE
Fixing sending buffered metrics delay

### DIFF
--- a/v1/plugin/stream_collector_proxy.go
+++ b/v1/plugin/stream_collector_proxy.go
@@ -21,7 +21,7 @@ const (
 type StreamProxy struct {
 	pluginProxy
 	plugin StreamCollector
-	ctx	context.Context
+	ctx    context.Context
 
 	// maxMetricsBuffer is the maximum number of metrics the plugin is buffering before sending metrics.
 	// Defaults to zero what means send metrics immediately.
@@ -116,8 +116,8 @@ func (p *StreamProxy) errorSend(errChan chan string, stream rpc.StreamCollector_
 func (p *StreamProxy) metricSend(taskID string, ch chan []Metric, stream rpc.StreamCollector_StreamMetricsServer) {
 	log.WithFields(
 		log.Fields{
-			"_block":			 "metricSend",
-			"task-id":			taskID,
+			"_block":             "metricSend",
+			"task-id":            taskID,
 			"maxMetricsBuffer":   p.maxMetricsBuffer,
 			"maxCollectDuration": p.maxCollectDuration,
 		},


### PR DESCRIPTION
There is a feature of buffering metrics and sending them in chunks. When a chunk (<MaxMetricsBuffer) is not filled with new metrics then is being sent after specific time (MaxCollectDuration).

Currently timer responsible for sending "partial" chunks is rescheduled after its being triggered. In result (MaxCollectDuration=55s in my case) "partial" chunk is sent after 55s, then after 50s, then after 45s. and so on.

After fix "partial" chunk is send always after 55s.



